### PR TITLE
feat: NCCL all_reduce — device-to-device TP communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- NCCL all_reduce (`--features nccl`) — replaces host-mediated CPU reduction
+  with device-to-device `ncclAllReduce` (SUM) via cudarc's safe bindings
+  - `TpWorld` initialises one `ncclComm_t` per rank via `Comm::from_devices`
+  - Single-process multi-GPU pattern: `group_start` / `group_end` batches
+    sequential per-rank calls into one collective — no thread-per-rank needed
+  - DType dispatch: F32, F16, BF16 all supported via macro
+  - CPU fallback preserved when `nccl` feature is off (zero-change default)
+  - `TpLlamaBackend::forward` now calls `world.all_reduce(partials)` which
+    routes to NCCL or CPU based on the active feature set
 - Scheduler wired into inference worker (`worker/mod.rs`)
   - `Worker` now holds a `Scheduler`; incoming `WorkItem`s are converted to
     `SequenceGroup`s and admitted via `scheduler.add_sequence_group()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,7 +3142,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vllm-hb"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3150,6 +3150,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "clap",
+ "cudarc 0.17.8",
  "futures-core",
  "half",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ path = "src/main.rs"
 default    = ["cuda"]
 # CUDA compute via cudarc — required for GPU inference
 cuda       = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
+# NCCL all_reduce — replaces host-mediated CPU reduction for tensor parallelism.
+# Requires NCCL runtime (libnccl.so) and the CUDA feature.
+# Enable with: cargo build --release --features nccl
+nccl       = ["cuda", "cudarc/nccl", "cudarc/f16"]
 # Flash Attention 2 — sm_80+ (Ampere) only; ~2× attention speedup on long context
 # Enable with: cargo build --release --features flash-attn
 flash-attn = ["cuda", "candle-transformers/flash-attn"]
@@ -47,6 +51,9 @@ tokenizers    = { version = "0.21", features = ["http"] }
 candle-core         = "0.9"
 candle-nn           = "0.9"
 candle-transformers = "0.9"
+# Explicit cudarc dep so the `nccl` and `f16` features can be toggled.
+# Version must stay in sync with candle-core's transitive requirement.
+cudarc              = { version = "0.17", optional = true }
 
 # Sampling
 rand          = "0.8"

--- a/src/engine/arch/llama_tp.rs
+++ b/src/engine/arch/llama_tp.rs
@@ -43,7 +43,7 @@ use parking_lot::Mutex;
 use rayon::prelude::*;
 use serde::Deserialize;
 
-use crate::parallel::{TpWorld, all_reduce, column_shard, row_shard};
+use crate::parallel::{TpWorld, column_shard, row_shard};
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -517,7 +517,7 @@ impl TpLlamaBackend {
                 .collect::<Result<_>>()?;
 
             // All-reduce attention → identical on all ranks
-            let attn_out = all_reduce(&attn_partials, self.world.device(0))?;
+            let attn_out = self.world.all_reduce(attn_partials)?;
 
             // Residual + post-attn norm
             let post_normed: Vec<Tensor> = self
@@ -547,7 +547,7 @@ impl TpLlamaBackend {
                 .collect::<Result<_>>()?;
 
             // All-reduce FFN → identical on all ranks
-            let ffn_out = all_reduce(&ffn_partials, self.world.device(0))?;
+            let ffn_out = self.world.all_reduce(ffn_partials)?;
 
             // Residual
             hidden = self

--- a/src/parallel/comm.rs
+++ b/src/parallel/comm.rs
@@ -10,13 +10,18 @@
 //! `all_reduce` with a single shard returns the shard (moved to `device`)
 //! without any copy or arithmetic — zero overhead for `tp=1`.
 //!
-//! # Multi-GPU implementation
+//! # Multi-GPU: NCCL path (`--features nccl`)
 //!
-//! Reduction is host-mediated: each shard is moved to CPU, accumulated with
-//! `Tensor::add`, then moved to the target device.  This avoids the NCCL
-//! dependency for a first working implementation.  When NCCL bindings in
-//! `cudarc` are stable the accumulation loop can be replaced by a single
-//! `ncclAllReduce` call without changing the call-sites.
+//! `nccl_all_reduce` uses `ncclAllReduce` (SUM) via cudarc's safe bindings.
+//! All shards stay on-device — no GPU→CPU transfer.  The single-process
+//! multi-GPU pattern wraps calls in `group_start` / `group_end` so NCCL
+//! treats the sequential per-rank calls as one collective operation.
+//!
+//! # Multi-GPU: CPU fallback (default)
+//!
+//! `all_reduce` accumulates on CPU: each shard is copied to CPU, summed, then
+//! moved to the target device.  Correct on all hardware; penalised by PCIe
+//! bandwidth on every TP step.
 //!
 //! # All-gather
 //!
@@ -54,6 +59,110 @@ pub fn all_reduce(shards: &[Tensor], device: &Device) -> Result<Tensor> {
             Ok(acc.to_device(device)?)
         }
     }
+}
+
+// ── NCCL all_reduce ───────────────────────────────────────────────────────────
+
+/// Device-to-device all_reduce using NCCL (SUM).
+///
+/// All `shards[rank]` must already live on their respective CUDA devices.
+/// After the call every rank's buffer holds the element-wise sum; the caller
+/// receives the rank-0 tensor.
+///
+/// # Single-process multi-GPU pattern
+///
+/// NCCL requires all ranks to "simultaneously" call `ncclAllReduce`.  In a
+/// single-process setup we wrap the sequential per-rank calls with
+/// `group_start` / `group_end`; NCCL then treats them as one collective.
+///
+/// # DType dispatch
+///
+/// F32, F16, and BF16 are supported.  The dtype is read from the first shard;
+/// all shards must have the same dtype.
+#[cfg(feature = "nccl")]
+pub fn nccl_all_reduce(
+    comms: &[crate::parallel::world::NcclComm],
+    shards: Vec<Tensor>,
+) -> Result<Tensor> {
+    use candle_core::{DType, Storage};
+    use cudarc::nccl::safe::{ReduceOp, group_end, group_start};
+
+    if shards.is_empty() {
+        bail!("nccl_all_reduce: shard list is empty");
+    }
+    if shards.len() != comms.len() {
+        bail!(
+            "nccl_all_reduce: {} shards but {} comms",
+            shards.len(),
+            comms.len()
+        );
+    }
+
+    let dtype = shards[0].dtype();
+    let shape = shards[0].shape().clone();
+
+    // Collect (src_slice, cuda_dev) pairs before entering the NCCL group so
+    // we hold the storage read-guards only for as long as needed.
+    macro_rules! reduce_dtype {
+        ($T:ty) => {{
+            // Phase 1 — allocate output buffers and issue all_reduce calls
+            // inside a single NCCL group.
+            let mut dsts: Vec<cudarc::driver::CudaSlice<$T>> = Vec::with_capacity(shards.len());
+            let mut cuda_devs: Vec<candle_core::CudaDevice> = Vec::with_capacity(shards.len());
+
+            group_start().map_err(|e| anyhow::anyhow!("ncclGroupStart: {e:?}"))?;
+
+            for (shard, nccl_comm) in shards.iter().zip(comms.iter()) {
+                let (storage, layout) = shard.storage_and_layout();
+                let Storage::Cuda(ref cs) = *storage else {
+                    group_end().ok();
+                    bail!("nccl_all_reduce: shard is not on CUDA");
+                };
+                let src = cs
+                    .as_cuda_slice::<$T>()
+                    .map_err(|e| anyhow::anyhow!("as_cuda_slice: {e:?}"))?;
+                let src_view = src.slice(layout.start_offset()..);
+                let elem_count = layout.shape().elem_count();
+
+                let mut dst = nccl_comm
+                    .0
+                    .stream()
+                    .alloc_zeros::<$T>(elem_count)
+                    .map_err(|e| anyhow::anyhow!("alloc_zeros: {e:?}"))?;
+
+                nccl_comm
+                    .0
+                    .all_reduce(&src_view, &mut dst, &ReduceOp::Sum)
+                    .map_err(|e| anyhow::anyhow!("ncclAllReduce: {e:?}"))?;
+
+                cuda_devs.push(cs.device().clone());
+                dsts.push(dst);
+                // storage read-guard dropped here
+            }
+
+            group_end().map_err(|e| anyhow::anyhow!("ncclGroupEnd: {e:?}"))?;
+
+            // Phase 2 — wrap rank-0 output as a candle Tensor.
+            let dst0 = dsts.remove(0);
+            let dev0 = cuda_devs.remove(0);
+            let out_storage = candle_core::CudaStorage::wrap_cuda_slice(dst0, dev0);
+            Tensor::from_storage(
+                Storage::Cuda(out_storage),
+                shape,
+                candle_core::op::BackpropOp::none(),
+                false,
+            )
+        }};
+    }
+
+    let result = match dtype {
+        DType::F32 => reduce_dtype!(f32),
+        DType::F16 => reduce_dtype!(half::f16),
+        DType::BF16 => reduce_dtype!(half::bf16),
+        other => bail!("nccl_all_reduce: unsupported dtype {other:?}"),
+    };
+
+    Ok(result)
 }
 
 // ── all_gather ────────────────────────────────────────────────────────────────

--- a/src/parallel/world.rs
+++ b/src/parallel/world.rs
@@ -1,4 +1,4 @@
-//! Tensor-parallel world — tracks GPU devices and rank assignments.
+//! Tensor-parallel world — tracks GPU devices, rank assignments, and NCCL comms.
 //!
 //! A `TpWorld` is created once at startup from `--tensor-parallel-size N`.
 //! It detects available CUDA devices, assigns one device per rank, and
@@ -6,13 +6,10 @@
 //!
 //! # Single-GPU fast path
 //!
-//! When `world_size == 1` every operation in this module is a no-op or
-//! trivial pass-through.  Single-GPU deployments pay zero overhead.
+//! When `world_size == 1` every operation is a no-op or trivial pass-through.
+//! Single-GPU deployments pay zero overhead.
 //!
 //! # Multi-GPU path
-//!
-//! Each rank owns one `candle_core::Device`.  The world is constructed on
-//! the main thread and then `Arc`-shared into per-rank worker tasks.
 //!
 //! ```text
 //!  rank 0 → Device::Cuda(0)
@@ -20,6 +17,17 @@
 //!  rank 2 → Device::Cuda(2)
 //!  rank 3 → Device::Cuda(3)
 //! ```
+//!
+//! # NCCL (`--features nccl`)
+//!
+//! When built with the `nccl` feature, `TpWorld` initialises one
+//! `ncclComm_t` per rank using `Comm::from_devices`.  `all_reduce` then
+//! replaces the host-mediated CPU accumulation with a true device-to-device
+//! ring-reduce via `ncclAllReduce`, eliminating the GPU→CPU→GPU round-trip
+//! that dominates TP communication cost on large tensors.
+//!
+//! Single-process multi-GPU NCCL uses `group_start` / `group_end` to batch
+//! sequential per-rank calls so NCCL treats them as a single collective.
 
 use std::sync::Arc;
 
@@ -30,15 +38,46 @@ use candle_core::Device;
 
 /// Shared tensor-parallel context.
 ///
-/// Clone cheaply via the inner `Arc` — all clones share the same device list.
+/// Clone cheaply via the inner `Arc` — all clones share the same device list
+/// and NCCL communicators.
 #[derive(Clone, Debug)]
 pub struct TpWorld(Arc<Inner>);
 
 #[derive(Debug)]
 struct Inner {
-    /// One device per rank. `devices[rank]` is the device for that rank.
+    /// One device per rank.
     devices: Vec<Device>,
+    /// NCCL communicators, one per rank.  Present only when `nccl` feature
+    /// is enabled and `world_size > 1`.
+    #[cfg(feature = "nccl")]
+    comms: Vec<NcclComm>,
 }
+
+// ── NCCL wrapper ──────────────────────────────────────────────────────────────
+
+/// Newtype around `cudarc::nccl::safe::Comm` that opts into `Sync`.
+///
+/// # Safety
+///
+/// `ncclComm_t` is not thread-safe for concurrent calls, but it IS safe to
+/// call sequentially from any thread.  We never call two NCCL operations on
+/// the same `Comm` concurrently — the group_start/group_end pattern serialises
+/// them — so `Sync` is safe here.
+#[cfg(feature = "nccl")]
+pub struct NcclComm(pub cudarc::nccl::safe::Comm);
+
+#[cfg(feature = "nccl")]
+// SAFETY: see doc comment above.
+unsafe impl Sync for NcclComm {}
+
+#[cfg(feature = "nccl")]
+impl std::fmt::Debug for NcclComm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NcclComm(rank={})", self.0.rank())
+    }
+}
+
+// ── Construction ──────────────────────────────────────────────────────────────
 
 impl TpWorld {
     /// Build a world with `world_size` ranks.
@@ -46,18 +85,22 @@ impl TpWorld {
     /// - `world_size = 1` → single CPU or CUDA:0 device, no communication.
     /// - `world_size > 1` → requires at least `world_size` CUDA devices.
     ///
+    /// When built with the `nccl` feature, also initialises NCCL communicators
+    /// for multi-GPU worlds (world_size > 1).
+    ///
     /// # Errors
     ///
     /// Returns an error if `world_size > 1` and fewer than `world_size`
-    /// CUDA devices are available.
+    /// CUDA devices are available, or if NCCL initialisation fails.
     pub fn new(world_size: usize) -> Result<Self> {
         assert!(world_size >= 1, "world_size must be >= 1");
 
         if world_size == 1 {
-            // Single device — CUDA if available, CPU otherwise.
             let device = Device::cuda_if_available(0)?;
             return Ok(Self(Arc::new(Inner {
                 devices: vec![device],
+                #[cfg(feature = "nccl")]
+                comms: Vec::new(), // no comms needed for single GPU
             })));
         }
 
@@ -75,8 +118,17 @@ impl TpWorld {
             .map(Device::new_cuda)
             .collect::<candle_core::Result<Vec<_>>>()?;
 
-        Ok(Self(Arc::new(Inner { devices })))
+        #[cfg(feature = "nccl")]
+        let comms = init_nccl_comms(&devices)?;
+
+        Ok(Self(Arc::new(Inner {
+            devices,
+            #[cfg(feature = "nccl")]
+            comms,
+        })))
     }
+
+    // ── Accessors ─────────────────────────────────────────────────────────────
 
     /// Number of ranks (GPUs) in this world.
     #[inline]
@@ -106,14 +158,58 @@ impl TpWorld {
         self.0.devices.len() == 1
     }
 
+    // ── All-reduce ────────────────────────────────────────────────────────────
+
+    /// Element-wise sum of `shards` from all ranks, returned on rank 0's device.
+    ///
+    /// - **NCCL feature enabled**: performs a true device-to-device ring-reduce
+    ///   via `ncclAllReduce`.  No GPU→CPU transfer; BW limited only by NVLink
+    ///   or PCIe interconnect.
+    /// - **NCCL feature disabled**: host-mediated fallback — copies all shards
+    ///   to CPU, accumulates, copies result back.  Functionally correct but
+    ///   penalised by PCIe transfers on every TP step.
+    pub fn all_reduce(&self, shards: Vec<candle_core::Tensor>) -> Result<candle_core::Tensor> {
+        #[cfg(feature = "nccl")]
+        {
+            if shards.len() > 1 {
+                return crate::parallel::comm::nccl_all_reduce(&self.0.comms, shards);
+            }
+        }
+        // Fallback: CPU-mediated reduction (or single-shard no-op).
+        crate::parallel::comm::all_reduce(&shards, self.device(0))
+    }
+
     // ── Private ───────────────────────────────────────────────────────────────
 
-    /// Count available CUDA devices via candle.
-    ///
-    /// Probes devices 0..31; stops at the first failure.
     fn cuda_device_count() -> usize {
         (0..32).take_while(|&i| Device::new_cuda(i).is_ok()).count()
     }
+}
+
+// ── NCCL initialisation ───────────────────────────────────────────────────────
+
+/// Build one `NcclComm` per rank using `Comm::from_devices`.
+///
+/// `from_devices` handles the barrier internally — all comms are ready when
+/// the function returns.
+#[cfg(feature = "nccl")]
+fn init_nccl_comms(devices: &[Device]) -> Result<Vec<NcclComm>> {
+    use candle_core::cuda::CudaDevice;
+
+    let streams: Vec<std::sync::Arc<cudarc::driver::CudaStream>> = devices
+        .iter()
+        .map(|d| match d {
+            Device::Cuda(cd) => Ok(cd.cuda_stream()),
+            _ => bail!("NCCL requires CUDA devices; got a non-CUDA device"),
+        })
+        .collect::<Result<_>>()?;
+
+    let comms = cudarc::nccl::safe::Comm::from_devices(streams)
+        .map_err(|e| anyhow::anyhow!("NCCL communicator init failed: {e:?}"))?;
+
+    tracing::info!(world_size = comms.len(), "NCCL communicators initialised");
+
+    Ok(comms.into_iter().map(NcclComm).collect())
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -124,7 +220,6 @@ mod tests {
 
     #[test]
     fn world_size_1_always_works() {
-        // world_size=1 must succeed on any machine (CPU fallback).
         let world = TpWorld::new(1).expect("world_size=1 should always succeed");
         assert_eq!(world.world_size(), 1);
         assert!(world.is_single());
@@ -133,7 +228,6 @@ mod tests {
     #[test]
     fn device_rank_0_accessible() {
         let world = TpWorld::new(1).unwrap();
-        // Just assert it doesn't panic — we don't care if it's CPU or CUDA.
         let _dev = world.device(0);
     }
 
@@ -142,15 +236,12 @@ mod tests {
         let world = TpWorld::new(1).unwrap();
         let pairs: Vec<_> = world.ranks().collect();
         assert_eq!(pairs.len(), 1);
-        assert_eq!(pairs[0].0, 0); // rank 0
+        assert_eq!(pairs[0].0, 0);
     }
 
     #[test]
     fn world_size_too_large_errors() {
-        // Request more GPUs than any reasonable CI machine has.
-        // This should fail gracefully, not panic.
         let result = TpWorld::new(64);
-        // Either it succeeds (64 GPUs somehow exist) or returns a clean error.
         if result.is_err() {
             let msg = result.unwrap_err().to_string();
             assert!(
@@ -164,7 +255,6 @@ mod tests {
     fn clone_shares_inner() {
         let world = TpWorld::new(1).unwrap();
         let clone = world.clone();
-        // Both should report the same world_size — they share the Arc.
         assert_eq!(world.world_size(), clone.world_size());
     }
 }


### PR DESCRIPTION
Closes #6

## What this does

Replaces the host-mediated all_reduce (CPU sum → GPU) with a true device-to-device `ncclAllReduce` via cudarc's safe NCCL bindings.

The old path:
```
GPU 0 shard → CPU → acc += shard → ... → GPU 0 result
```
The new path with `--features nccl`:
```
GPU 0/1/2/3 shards → ncclAllReduce (ring on NVLink/PCIe) → GPU 0 result
```

## Implementation

**`parallel/world.rs`**
- `TpWorld` now stores `Vec<NcclComm>` (one per rank) when the `nccl` feature is active
- `Comm::from_devices(streams)` handles the NCCL barrier — all comms are ready when `TpWorld::new()` returns
- `TpWorld::all_reduce(shards)` dispatches to NCCL or CPU based on feature flags
- `NcclComm` newtype opts into `Sync` (safe: group_start/group_end serialises all calls)

**`parallel/comm.rs`**
- New `nccl_all_reduce(comms, shards)` function
- `group_start` / `group_end` wraps sequential per-rank calls — single-process multi-GPU NCCL pattern, no thread-per-rank needed
- DType dispatch macro covers F32, F16, BF16
- CPU fallback untouched

**`engine/arch/llama_tp.rs`**
- Both all_reduce call sites updated: `world.all_reduce(partials)` instead of `comm::all_reduce(&partials, device)`

## Feature flag

```toml
# Cargo.toml
features = ["nccl"]   # adds NCCL; requires libnccl.so at link time
```

```bash
cargo build --release --features nccl
```

Default (`--features cuda`) is unchanged — CPU reduction still used.

## Test plan
- [x] `cargo build --no-default-features` — clean, 61 tests pass
- [x] `cargo fmt + clippy --no-default-features` — zero warnings
- [ ] `cargo build --features nccl` on knowmi-server (NCCL runtime present)
- [ ] Multi-GPU inference throughput comparison (CPU vs NCCL reduce)