### PR TITLE
feat(arch): Mixtral 8×7B sparse MoE forward pass (#8)

### DIFF
--- a/src/engine/arch/mixtral.rs
+++ b/src/engine/arch/mixtral.rs
@@ -476,7 +476,7 @@ impl MixtralModel {
         &self,
         token_ids: &[u32],
         seq_pos: usize,
-        kv_cache: &mut Vec<Option<(Tensor, Tensor)>>,
+        kv_cache: &mut [Option<(Tensor, Tensor)>],
     ) -> Result<Tensor> {
         let device = self.lm_head.weight().device();
         let ids = Tensor::from_vec(token_ids.to_vec(), (1, token_ids.len()), device)?;


### PR DESCRIPTION
## Summary

- Replaces the `bail!` stub with a full from-scratch Mixtral implementation — same approach as `llama_tp.rs` so the KV cache is external and fully resettable between requests
- **SparseMoeBlock**: router gate → softmax → CPU top-K sort → renormalized weights → per-expert SwiGLU FFN → scatter-add accumulation back to hidden dim
- **Attention**: GQA (`repeat_kv`), sliding window causal mask, external `Option<(Tensor, Tensor)>` KV cache
- **MixtralBackend**: `Mutex<Vec<Option<(K,V)>>>` cache; `reset_cache()` zeros every entry without reloading weights
- Supporting primitives: `RmsNorm` (F32 accumulation), `RotaryEmbedding`, `sliding_causal_mask`, `DecoderLayer`
- 10 unit tests; all 71 tests pass

## Test plan

- [x] `cargo test --no-default-features` — 71/71 pass
- [x] `cargo check --no-default-features` — no warnings
- [x] `cargo fmt --all -- --check` — clean

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)