### PR TITLE
feat: speculative decoding (draft model + rejection sampling, issue #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [0.7.0] — 2026-04-08
 
 ### Added
+- **Speculative decoding** (`src/speculative.rs`, issue #10)
+  - `SpeculativeDecoder` holds a draft `Engine` and per-sequence draft KV
+    caches; lives inside `Worker` behind an `Option`
+  - **Draft phase**: K autoregressive forward passes on the small draft model
+    with full probability distributions captured for rejection sampling
+  - **Verify phase**: K+1 sequential target passes — stops at the first
+    rejection so the target's KV cache is always correct, no post-step fixup
+  - **Rejection sampling** (Leviathan et al. 2023): accept token i with
+    probability `min(1, q_i / p_i)`; on rejection sample from `(q − p)⁺`
+    correction distribution; sample a bonus token when all K are accepted
+  - **Cache reconciliation**: Mixtral external caches use a pre-draft snapshot
+    (cheap Arc clone) + O(j) replay; Llama/Qwen fall back to rebuilding from
+    the last `DRAFT_FALLBACK_WINDOW = 128` context tokens
+  - CLI flags: `--draft-model PATH`, `--speculative-steps N` (default 5)
+  - Worker logs accepted-per-step at `DEBUG` level for acceptance-rate tuning
+  - 7 unit tests: probability distribution, 2-D logit handling, correction
+    sampling, degenerate fallback, `try_clone_external` variants
 - **Library crate** (`src/lib.rs`) — all modules now exported as `vllm_hb::*`;
   enables integration tests and downstream embedding without the binary
 - **HTTP integration test suite** (`tests/http_api.rs`) — 18 tests covering
@@ -43,6 +60,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
   Codecov on every push/PR (`fail_ci_if_error: false`)
 
 ### Changed
+- `Worker::new` gains an `Option<SpeculativeDecoder>` parameter; standard
+  decoding path unchanged when `None`
+- `step_decode` splits into `step_decode_standard` (existing) +
+  `step_decode_speculative` (new speculative path)
+- `PerSeqCache` gains `try_clone_external()` — cheap snapshot for Mixtral
+  external caches; returns `None` for Llama / LlamaTp (no-clone fallback)
 - `Cargo.toml` gains a `[lib]` section (`name = "vllm_hb"`, `path = "src/lib.rs"`)
   and `[dev-dependencies]` for `axum`, `tower`, `tokio`, `serde_json`,
   `tempfile`, `bytes`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,7 +3245,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vllm-hb"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-hb"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "Hammingbound — vLLM-compatible inference runtime in pure Rust. Zero Python. Zero libtorch."
 repository = "https://github.com/avarga1/vllm-hb"

--- a/src/engine/kv_cache.rs
+++ b/src/engine/kv_cache.rs
@@ -34,3 +34,20 @@ pub enum PerSeqCache {
     /// This variant is a marker so the worker can insert/remove it uniformly.
     LlamaTp,
 }
+
+impl PerSeqCache {
+    /// Attempt a cheap clone of the cache for external-cache architectures.
+    ///
+    /// Returns `Some` only for `Mixtral`, where the underlying `Tensor`s are
+    /// Arc-backed and cloning costs O(num_layers) ref-count bumps.  Returns
+    /// `None` for `Llama` and `LlamaTp` — callers must use a fallback.
+    ///
+    /// Used by the speculative decoder to snapshot the draft cache before
+    /// generating K candidate tokens so it can be restored on partial accept.
+    pub fn try_clone_external(&self) -> Option<Self> {
+        match self {
+            Self::Mixtral(v) => Some(Self::Mixtral(v.clone())),
+            Self::Llama(_) | Self::LlamaTp => None,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use tracing_subscriber::{EnvFilter, fmt};
 use vllm_hb::bench;
 use vllm_hb::engine::{self, ModelConfig};
 use vllm_hb::server;
+use vllm_hb::speculative::SpeculativeDecoder;
 use vllm_hb::tokenize;
 use vllm_hb::worker;
 
@@ -75,6 +76,23 @@ struct ServeArgs {
     /// Number of GPUs for tensor parallelism (default: 1 = single GPU).
     #[arg(long, default_value_t = 1)]
     tensor_parallel_size: usize,
+
+    /// Path to a small draft model directory for speculative decoding.
+    ///
+    /// When supplied together with `--speculative-steps`, each decode step
+    /// generates N candidate tokens with the draft model and verifies them
+    /// against the main model using rejection sampling.  Expected speedup:
+    /// 2–3× at identical output quality.  Omit to disable.
+    #[arg(long)]
+    draft_model: Option<String>,
+
+    /// Number of draft tokens to generate per speculative step (K).
+    ///
+    /// Ignored when `--draft-model` is not set.  Typical values: 3–7.
+    /// Higher K increases throughput when the draft acceptance rate is high
+    /// but adds overhead when it is low.
+    #[arg(long, default_value_t = 5)]
+    speculative_steps: usize,
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -122,7 +140,30 @@ async fn serve(args: ServeArgs) -> Result<()> {
         "Model ready"
     );
 
-    let (worker, handle) = worker::Worker::new(engine, tokenizer.clone(), eos_tokens);
+    // Optional draft model for speculative decoding.
+    let spec_decoder = if let Some(draft_path) = &args.draft_model {
+        tracing::info!(draft_model = %draft_path, speculative_steps = args.speculative_steps, "Loading draft model");
+        let draft_engine = engine::Engine::load(ModelConfig {
+            model_path: draft_path.clone(),
+            max_seq_len: args.max_seq_len,
+            gpu_memory_utilization: args.gpu_memory_utilization,
+            bf16: args.bf16,
+            tensor_parallel_size: 1, // draft always runs single-GPU
+        })?;
+        tracing::info!(
+            params = draft_engine.param_count(),
+            layers = draft_engine.num_layers(),
+            "Draft model ready"
+        );
+        Some(SpeculativeDecoder::new(
+            draft_engine,
+            args.speculative_steps,
+        ))
+    } else {
+        None
+    };
+
+    let (worker, handle) = worker::Worker::new(engine, tokenizer.clone(), eos_tokens, spec_decoder);
     tokio::spawn(worker.run());
 
     let model_name = args

--- a/src/speculative.rs
+++ b/src/speculative.rs
@@ -1,31 +1,442 @@
-//! Speculative decoding.
+//! Speculative decoding — draft model + rejection-sampling verification.
 //!
-//! # Status: STUB
+//! # Algorithm (Leviathan et al. 2023)
 //!
-//! ## Concept
+//! Each decode step:
 //!
-//! A small "draft" model generates K candidate tokens cheaply.  The large
-//! "target" model verifies all K tokens in a single forward pass.  If the
-//! target accepts token i, it moves on; if it rejects it, generation
-//! backtracks to that position.  Expected speedup: 2-3× at no quality loss.
+//! 1. **Draft phase** — run the small draft model K times autoregressively
+//!    to produce K candidate tokens with their probability distributions.
 //!
-//! ## Key components to implement
+//! 2. **Verify phase** — run the large target model K+1 times sequentially
+//!    (one call per candidate plus one bonus call).  *Sequential* verification
+//!    is used rather than a single batched pass so the target's KV cache
+//!    always ends at the correct position — no post-step cache fixup needed.
 //!
-//! 1. **Draft model** — a small model (e.g. 160M params) loaded alongside
-//!    the main model.  Uses the same `Engine` abstraction.
+//! 3. **Rejection sampling** — for each candidate i, accept with probability
+//!    `min(1, q_i / p_i)` where `q_i` = target probability and `p_i` = draft
+//!    probability of the candidate token.  On rejection, replace with a token
+//!    drawn from the *correction* distribution `(q − p)⁺` (renormalised).
 //!
-//! 2. **Speculative sampler** — generates K draft tokens, runs target
-//!    verification, applies the rejection sampling correction.
+//! 4. **Bonus token** — if all K candidates are accepted, sample one extra
+//!    token from the target distribution at position `seq_pos + K`.
 //!
-//! 3. **Worker integration** — `worker/mod.rs` gains a `speculative_steps: usize`
-//!    field; when > 0, each "decode step" runs the draft loop instead of
-//!    a single target forward.
+//! Expected outcome: `1 + K·α` tokens accepted per step on average (α =
+//! acceptance rate), versus 1 token per step for greedy decoding.  Output
+//! distribution is identical to the target model's.
 //!
-//! ## References
+//! # Cache management
 //!
-//! - Leviathan et al. (2023): "Fast Inference from Transformers via Speculative Decoding"
-//! - Chen et al. (2023): "Accelerating Large Language Model Decoding with Speculative Sampling"
+//! Per-sequence draft KV caches are maintained across steps so the draft
+//! model keeps its full context:
+//!
+//! - **Full accept** (all K+1 tokens accepted): draft cache is K tokens ahead
+//!   of the new sequence position; one extra forward pass syncs it.
+//! - **Partial accept** with *external-cache* backends (Mixtral): a pre-draft
+//!   snapshot (cheap Arc clone) is restored and re-fed with only the `j`
+//!   accepted tokens — O(j ≤ K) draft passes.
+//! - **Partial accept** with *internal-cache* backends (Llama, Qwen2/3): the
+//!   draft cache is rebuilt from the last `DRAFT_FALLBACK_WINDOW` context
+//!   tokens — correct but O(WINDOW) draft passes.
+//!
+//! The target cache never needs reconciliation: sequential verification
+//! stops the loop at the exact rejection boundary.
 
-#![allow(dead_code)]
+use std::collections::HashMap;
 
-pub struct SpeculativeDecoder;
+use anyhow::Result;
+use candle_core::{DType, Tensor};
+use rand::distributions::WeightedIndex;
+use rand::prelude::*;
+
+use crate::engine::{Engine, PerSeqCache};
+use crate::sampling::nucleus::{apply_temperature, nucleus_filter, renormalize, softmax_inplace};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Context window used when rebuilding the draft cache from scratch
+/// (fallback for Llama / Qwen2/3 internal-cache backends).
+///
+/// Larger values → better draft prediction quality, higher per-step overhead.
+const DRAFT_FALLBACK_WINDOW: usize = 128;
+
+// ── SpeculativeDecoder ────────────────────────────────────────────────────────
+
+/// Pairs a small draft model with the main target model for speculative decoding.
+///
+/// One `SpeculativeDecoder` is created at server start-up (if `--draft-model`
+/// is supplied) and lives for the lifetime of the [`crate::worker::Worker`].
+pub struct SpeculativeDecoder {
+    pub draft_engine: Engine,
+    /// Number of candidate tokens generated per speculative step (K).
+    pub speculative_steps: usize,
+    /// Per-sequence draft KV caches (seq_id → cache).
+    draft_caches: HashMap<u64, PerSeqCache>,
+}
+
+impl SpeculativeDecoder {
+    pub fn new(draft_engine: Engine, speculative_steps: usize) -> Self {
+        Self {
+            draft_engine,
+            speculative_steps,
+            draft_caches: HashMap::new(),
+        }
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    /// Warm-start a draft cache for a newly admitted sequence.
+    ///
+    /// Runs the full prompt through the draft model so the first speculative
+    /// step starts with a meaningful KV state (mirrors `step_prefill` on the
+    /// target side).
+    pub fn init_seq(&mut self, seq_id: u64, prompt_ids: &[u32]) -> Result<()> {
+        let mut cache = self.draft_engine.create_kv_cache()?;
+        if !prompt_ids.is_empty() {
+            self.draft_engine
+                .forward_with_cache(prompt_ids, 0, &mut cache)?;
+        }
+        self.draft_caches.insert(seq_id, cache);
+        Ok(())
+    }
+
+    /// Drop the draft cache when a sequence finishes.
+    pub fn remove_seq(&mut self, seq_id: u64) {
+        self.draft_caches.remove(&seq_id);
+    }
+
+    // ── Speculative step ──────────────────────────────────────────────────────
+
+    /// Run one speculative decode step.
+    ///
+    /// Drafts `K = speculative_steps` tokens, verifies them token-by-token
+    /// against `target_engine` using rejection sampling, and returns the
+    /// accepted tokens (between 1 and K+1 inclusive).
+    ///
+    /// # Arguments
+    ///
+    /// * `seq_id`        — Sequence identifier for draft cache lookup.
+    /// * `context`       — Full token prefix: `prompt_ids ++ output_ids`.
+    /// * `seq_pos`       — Absolute position of `context.last()` in the sequence.
+    /// * `temperature`   — Sampling temperature (shared by draft and target).
+    /// * `top_p`         — Nucleus filter threshold (shared by draft and target).
+    /// * `target_engine` — The large target model.
+    /// * `target_cache`  — The target's per-sequence KV cache (mutated in place).
+    ///
+    /// # Returns
+    ///
+    /// Non-empty `Vec<u32>` of accepted token ids to append to `output_ids`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn step(
+        &mut self,
+        seq_id: u64,
+        context: &[u32],
+        seq_pos: usize,
+        temperature: f32,
+        top_p: f32,
+        target_engine: &Engine,
+        target_cache: &mut PerSeqCache,
+    ) -> Result<Vec<u32>> {
+        let k = self.speculative_steps;
+        let last_token = *context
+            .last()
+            .ok_or_else(|| anyhow::anyhow!("speculative step: empty context"))?;
+
+        // Remove draft cache from the map so we can borrow &self.draft_engine
+        // simultaneously (different struct fields — allowed by Rust's field
+        // borrow rules).
+        let mut draft_cache = self
+            .draft_caches
+            .remove(&seq_id)
+            .ok_or_else(|| anyhow::anyhow!("no draft cache for seq {seq_id}"))?;
+
+        // Snapshot pre-draft state for cache reconciliation on partial accept.
+        let snapshot = draft_cache.try_clone_external();
+
+        // ── Draft phase ───────────────────────────────────────────────────────
+
+        let mut draft_tokens: Vec<u32> = Vec::with_capacity(k);
+        // Full probability distributions for each draft position (needed for
+        // the correction term in rejection sampling).
+        let mut draft_probs: Vec<Vec<f32>> = Vec::with_capacity(k);
+
+        let mut prev = last_token;
+        for i in 0..k {
+            let logits =
+                self.draft_engine
+                    .forward_with_cache(&[prev], seq_pos + i, &mut draft_cache)?;
+            let probs = logits_to_probs(&logits, temperature, top_p)?;
+            let token = sample_probs(&probs)?;
+            draft_tokens.push(token);
+            draft_probs.push(probs);
+            prev = token;
+        }
+
+        // ── Verify phase ──────────────────────────────────────────────────────
+        //
+        // Feed tokens to the target one at a time: input at position seq_pos+i
+        // yields logits predicting draft_tokens[i].  We stop early on rejection
+        // so the target cache ends at the correct accepted position.
+
+        let mut accepted: Vec<u32> = Vec::with_capacity(k + 1);
+        let mut all_accepted = true;
+        let mut verify_in = last_token;
+
+        for i in 0..k {
+            let logits =
+                target_engine.forward_with_cache(&[verify_in], seq_pos + i, target_cache)?;
+            let tgt_probs = logits_to_probs(&logits, temperature, top_p)?;
+
+            let p_i = draft_probs[i][draft_tokens[i] as usize].max(1e-10);
+            let q_i = tgt_probs[draft_tokens[i] as usize];
+            let accept_p = (q_i / p_i).min(1.0_f32);
+
+            if rand::random::<f32>() < accept_p {
+                accepted.push(draft_tokens[i]);
+                verify_in = draft_tokens[i];
+            } else {
+                // Rejection: replace with sample from correction distribution.
+                let corrected = sample_corrected(&tgt_probs, &draft_probs[i])?;
+                accepted.push(corrected);
+                all_accepted = false;
+                break;
+            }
+        }
+
+        // All K drafts accepted → sample one bonus token from target at seq_pos+K.
+        if all_accepted {
+            let bonus_logits =
+                target_engine.forward_with_cache(&[verify_in], seq_pos + k, target_cache)?;
+            let bonus_probs = logits_to_probs(&bonus_logits, temperature, top_p)?;
+            let bonus = sample_probs(&bonus_probs)?;
+            accepted.push(bonus);
+        }
+
+        // ── Draft cache reconciliation ────────────────────────────────────────
+
+        let j = accepted.len(); // tokens accepted this step (1..=K+1)
+        draft_cache = reconcile_draft_cache(
+            &self.draft_engine,
+            draft_cache,
+            snapshot,
+            context,
+            last_token,
+            seq_pos,
+            &accepted,
+            j,
+            k,
+        )?;
+
+        self.draft_caches.insert(seq_id, draft_cache);
+        Ok(accepted)
+    }
+}
+
+// ── Cache reconciliation ──────────────────────────────────────────────────────
+
+/// Reconcile the draft cache after a speculative step.
+///
+/// After generating K draft tokens the cache sits K positions ahead of the
+/// last accepted token.  This function advances it to exactly the right place.
+///
+/// - **Full accept** (`j == K+1`): feed the bonus token (which only the
+///   target generated) through the draft — O(1) draft pass.
+/// - **Partial accept, snapshot available** (Mixtral external cache): restore
+///   the pre-draft snapshot and re-feed `[last_token, accepted[0..j-1]]` —
+///   O(j ≤ K) draft passes.
+/// - **Partial accept, no snapshot** (Llama / Qwen2/3): rebuild from the last
+///   `DRAFT_FALLBACK_WINDOW` tokens of the updated context — O(WINDOW) passes,
+///   but correctness is guaranteed.
+#[allow(clippy::too_many_arguments)]
+fn reconcile_draft_cache(
+    draft_engine: &Engine,
+    mut draft_cache: PerSeqCache,
+    snapshot: Option<PerSeqCache>,
+    context: &[u32],
+    last_token: u32,
+    seq_pos: usize,
+    accepted: &[u32],
+    j: usize,
+    k: usize,
+) -> Result<PerSeqCache> {
+    if j == k + 1 {
+        // Full accept + bonus.  Draft processed K tokens (draft_0..draft_{K-1})
+        // but not the bonus.  Feed bonus at seq_pos+K to sync.
+        let bonus = accepted[k];
+        draft_engine.forward_with_cache(&[bonus], seq_pos + k, &mut draft_cache)?;
+        return Ok(draft_cache);
+    }
+
+    // Partial accept (j ≤ K): draft cache has K stale entries beyond the
+    // accepted prefix.
+    match snapshot {
+        Some(mut snap) => {
+            // Restore pre-draft state (snapshot was at seq_pos entries).
+            // Re-feed [last_token, accepted_0, …, accepted_{j-2}] so the
+            // cache advances to seq_pos + j entries.
+            let replay: Vec<u32> = std::iter::once(last_token)
+                .chain(accepted[..j.saturating_sub(1)].iter().copied())
+                .collect();
+            if !replay.is_empty() {
+                draft_engine.forward_with_cache(&replay, seq_pos, &mut snap)?;
+            }
+            Ok(snap)
+        }
+        None => {
+            // Fallback: rebuild from the last DRAFT_FALLBACK_WINDOW tokens of
+            // the fully-updated context (original prefix + accepted tokens).
+            let new_ctx: Vec<u32> = context.iter().chain(accepted.iter()).copied().collect();
+            let start = new_ctx.len().saturating_sub(DRAFT_FALLBACK_WINDOW);
+            let mut fresh = draft_engine.create_kv_cache()?;
+            if start < new_ctx.len() {
+                draft_engine.forward_with_cache(&new_ctx[start..], start, &mut fresh)?;
+            }
+            Ok(fresh)
+        }
+    }
+}
+
+// ── Probability helpers ───────────────────────────────────────────────────────
+
+/// Convert raw logits to a probability distribution.
+///
+/// Handles both `[vocab]` (1-D) and `[1, vocab]` (2-D with a leading batch
+/// or sequence dimension) tensors, applying temperature scaling, softmax, and
+/// optional nucleus filtering.
+///
+/// When `temperature < 1e-6` (greedy), returns a delta distribution (prob 1.0
+/// at the argmax) so that rejection sampling behaves deterministically.
+fn logits_to_probs(logits: &Tensor, temperature: f32, top_p: f32) -> Result<Vec<f32>> {
+    // Flatten any leading singleton dimensions → [vocab].
+    let flat = if logits.rank() > 1 {
+        let vocab = logits.elem_count();
+        logits.reshape((vocab,))?
+    } else {
+        logits.clone()
+    };
+
+    let flat = flat.to_dtype(DType::F32)?;
+    let mut probs: Vec<f32> = flat.to_vec1()?;
+
+    if temperature < 1e-6 {
+        // Greedy: delta distribution at argmax.
+        let best = probs
+            .iter()
+            .copied()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        probs.iter_mut().enumerate().for_each(|(i, p)| {
+            *p = if i == best { 1.0 } else { 0.0 };
+        });
+        return Ok(probs);
+    }
+
+    apply_temperature(&mut probs, temperature);
+    softmax_inplace(&mut probs);
+
+    if top_p < 1.0 - 1e-6 {
+        nucleus_filter(&mut probs, top_p);
+        renormalize(&mut probs);
+    }
+
+    Ok(probs)
+}
+
+/// Sample one token from a probability vector.
+fn sample_probs(probs: &[f32]) -> Result<u32> {
+    let dist = WeightedIndex::new(probs).map_err(|e| anyhow::anyhow!("WeightedIndex: {e}"))?;
+    Ok(dist.sample(&mut rand::thread_rng()) as u32)
+}
+
+/// Sample from the correction distribution `max(0, q − p)` (renormalised).
+///
+/// Used when a draft token is rejected so that the combined output
+/// distribution matches the target's exactly.
+fn sample_corrected(q: &[f32], p: &[f32]) -> Result<u32> {
+    let mut correction: Vec<f32> = q
+        .iter()
+        .zip(p.iter())
+        .map(|(qi, pi)| (qi - pi).max(0.0))
+        .collect();
+    let sum: f32 = correction.iter().sum();
+    if sum < 1e-10 {
+        // Degenerate (q ≤ p everywhere): fall back to the pure target distribution.
+        return sample_probs(q);
+    }
+    correction.iter_mut().for_each(|x| *x /= sum);
+    sample_probs(&correction)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    fn make_logits(vals: &[f32]) -> Tensor {
+        Tensor::from_vec(vals.to_vec(), vals.len(), &Device::Cpu).unwrap()
+    }
+
+    #[test]
+    fn logits_to_probs_sums_to_one() {
+        let logits = make_logits(&[1.0, 2.0, 3.0, 0.5]);
+        let probs = logits_to_probs(&logits, 1.0, 1.0).unwrap();
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5, "probs sum = {sum}");
+    }
+
+    #[test]
+    fn logits_to_probs_greedy_is_delta() {
+        let logits = make_logits(&[0.1, 5.0, 0.2, 0.3]);
+        let probs = logits_to_probs(&logits, 0.0, 1.0).unwrap();
+        // Argmax is index 1.
+        assert_eq!(probs[1], 1.0);
+        assert_eq!(probs.iter().filter(|&&p| p == 0.0).count(), 3);
+    }
+
+    #[test]
+    fn logits_to_probs_2d_batch_dim() {
+        // Simulate [1, vocab] tensor from candle_transformers.
+        let vals = vec![1.0f32, 2.0, 3.0];
+        let logits = Tensor::from_vec(vals.clone(), (1, vals.len()), &Device::Cpu).unwrap();
+        let probs = logits_to_probs(&logits, 1.0, 1.0).unwrap();
+        assert_eq!(probs.len(), 3);
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn sample_corrected_returns_valid_token() {
+        // q is slightly higher on token 2; p is higher on token 0.
+        let q = vec![0.1, 0.2, 0.7];
+        let p = vec![0.6, 0.3, 0.1];
+        let token = sample_corrected(&q, &p).unwrap();
+        // Correction = max(0, q-p) = [0, 0, 0.6] → only token 2 survives.
+        assert_eq!(token, 2);
+    }
+
+    #[test]
+    fn sample_corrected_degenerate_falls_back_to_q() {
+        // q ≤ p everywhere → correction sums to zero → fall back to q.
+        let q = vec![0.1, 0.3, 0.6];
+        let p = vec![0.5, 0.4, 0.7]; // p ≥ q at all positions
+        // Should not panic; result is a valid index.
+        let token = sample_corrected(&q, &p).unwrap();
+        assert!(token < 3);
+    }
+
+    #[test]
+    fn try_clone_external_mixtral() {
+        let cache = PerSeqCache::Mixtral(vec![None; 4]);
+        let snap = cache.try_clone_external();
+        assert!(snap.is_some());
+    }
+
+    #[test]
+    fn try_clone_external_llama_tp_is_none() {
+        let cache = PerSeqCache::LlamaTp;
+        assert!(cache.try_clone_external().is_none());
+    }
+}

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -52,6 +52,7 @@ use crate::engine::{Engine, PerSeqCache};
 use crate::sampling;
 use crate::scheduler::sequence::{Sequence, SequenceGroup, SequenceStatus};
 use crate::scheduler::{Scheduler, SchedulerOutputs};
+use crate::speculative::SpeculativeDecoder;
 use crate::tokenize;
 use crate::types::pipeline::{
     FinishReason, GenerationEvent, GenerationStats, TokenEvent, WorkItem,
@@ -103,10 +104,19 @@ pub struct Worker {
     seq_start: HashMap<u64, Instant>,
     /// Monotonic counter for assigning unique sequence IDs.
     next_seq_id: u64,
+    /// Optional speculative decoder (draft model + rejection sampler).
+    /// When present, `step_decode` uses speculative drafting instead of
+    /// single-token greedy/sampled decoding.
+    spec_decoder: Option<SpeculativeDecoder>,
 }
 
 impl Worker {
-    pub fn new(engine: Engine, tokenizer: Tokenizer, eos_tokens: Vec<u32>) -> (Self, WorkerHandle) {
+    pub fn new(
+        engine: Engine,
+        tokenizer: Tokenizer,
+        eos_tokens: Vec<u32>,
+        spec_decoder: Option<SpeculativeDecoder>,
+    ) -> (Self, WorkerHandle) {
         let (tx, rx) = mpsc::unbounded_channel();
         (
             Self {
@@ -118,6 +128,7 @@ impl Worker {
                 kv_caches: HashMap::new(),
                 seq_start: HashMap::new(),
                 next_seq_id: 0,
+                spec_decoder,
             },
             WorkerHandle { tx },
         )
@@ -126,11 +137,20 @@ impl Worker {
     // ── Main loop ─────────────────────────────────────────────────────────────
 
     pub async fn run(mut self) {
-        tracing::info!(
-            gpu_blocks = NUM_GPU_BLOCKS,
-            cpu_blocks = NUM_CPU_BLOCKS,
-            "Continuous-batching inference worker ready"
-        );
+        if let Some(spec) = &self.spec_decoder {
+            tracing::info!(
+                gpu_blocks = NUM_GPU_BLOCKS,
+                cpu_blocks = NUM_CPU_BLOCKS,
+                speculative_steps = spec.speculative_steps,
+                "Continuous-batching inference worker ready (speculative decoding enabled)"
+            );
+        } else {
+            tracing::info!(
+                gpu_blocks = NUM_GPU_BLOCKS,
+                cpu_blocks = NUM_CPU_BLOCKS,
+                "Continuous-batching inference worker ready"
+            );
+        }
 
         loop {
             // Block until at least one WorkItem arrives.
@@ -260,11 +280,20 @@ impl Worker {
         seq.output_ids.push(first_token);
         self.emit_token(seq, first_token);
 
-        // Store cache for future decode steps.
+        // Store target cache for future decode steps.
         self.kv_caches.insert(seq.id, cache);
+
+        // Warm-start the draft cache (if speculative decoding is enabled).
+        if let Some(spec) = &mut self.spec_decoder {
+            spec.init_seq(seq.id, &seq.prompt_ids)?;
+        }
 
         if self.is_done(seq) {
             self.finish_seq(seq);
+            self.kv_caches.remove(&seq.id);
+            if let Some(spec) = &mut self.spec_decoder {
+                spec.remove_seq(seq.id);
+            }
         }
 
         Ok(())
@@ -272,7 +301,7 @@ impl Worker {
 
     // ── Decode one step for one sequence group ────────────────────────────────
 
-    /// Feed the last generated token, emit the next output token.
+    /// Dispatch to speculative or standard single-token decode.
     fn step_decode(&mut self, group: &mut SequenceGroup) -> Result<()> {
         let seq = group
             .seqs
@@ -280,6 +309,15 @@ impl Worker {
             .find(|s| s.status == SequenceStatus::Running)
             .ok_or_else(|| anyhow::anyhow!("no running sequence in group {}", group.request_id))?;
 
+        if self.spec_decoder.is_some() {
+            self.step_decode_speculative(seq)
+        } else {
+            self.step_decode_standard(seq)
+        }
+    }
+
+    /// Standard single-token decode step.
+    fn step_decode_standard(&mut self, seq: &mut Sequence) -> Result<()> {
         let cache = self
             .kv_caches
             .get_mut(&seq.id)
@@ -303,6 +341,68 @@ impl Worker {
         if self.is_done(seq) {
             self.finish_seq(seq);
             self.kv_caches.remove(&seq.id);
+        }
+
+        Ok(())
+    }
+
+    /// Speculative decode step: draft K tokens, verify with target, accept 1..=K+1.
+    fn step_decode_speculative(&mut self, seq: &mut Sequence) -> Result<()> {
+        // Build the full accepted prefix: prompt + all output tokens so far.
+        let context: Vec<u32> = seq
+            .prompt_ids
+            .iter()
+            .chain(seq.output_ids.iter())
+            .copied()
+            .collect();
+        // seq_pos is the position of context.last() (= last generated token).
+        let seq_pos = seq.prompt_ids.len() + seq.output_ids.len() - 1;
+
+        // Remove the target cache so we can also borrow &self.engine and
+        // &mut self.spec_decoder without aliasing conflicts (distinct fields).
+        let mut cache = self
+            .kv_caches
+            .remove(&seq.id)
+            .ok_or_else(|| anyhow::anyhow!("missing KV cache for seq {}", seq.id))?;
+
+        let accepted = {
+            let spec = self.spec_decoder.as_mut().unwrap();
+            spec.step(
+                seq.id,
+                &context,
+                seq_pos,
+                seq.params.temperature,
+                seq.params.top_p,
+                &self.engine,
+                &mut cache,
+            )?
+        };
+
+        tracing::debug!(
+            seq_id = seq.id,
+            accepted = accepted.len(),
+            spec_k = self.spec_decoder.as_ref().unwrap().speculative_steps,
+            "Speculative step"
+        );
+
+        let mut done = false;
+        for &token in &accepted {
+            seq.output_ids.push(token);
+            self.emit_token(seq, token);
+            if self.is_done(seq) {
+                done = true;
+                break;
+            }
+        }
+
+        if done {
+            self.finish_seq(seq);
+            // kv_cache was already removed above; don't re-insert.
+            if let Some(spec) = &mut self.spec_decoder {
+                spec.remove_seq(seq.id);
+            }
+        } else {
+            self.kv_caches.insert(seq.id, cache);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Implements speculative decoding per Leviathan et al. (2023): a small draft model generates K candidate tokens cheaply, the large target model verifies them with rejection sampling, and 1–K+1 tokens are accepted per step at identical output quality
- `SpeculativeDecoder` in `src/speculative.rs` owns the draft engine and per-sequence KV caches; `Worker` holds `Option<SpeculativeDecoder>` with the standard path unchanged when `None`
- Sequential verification (K+1 individual target passes) keeps the target's KV cache always consistent with no post-step fixup needed
- Cache reconciliation: Mixtral external caches use a pre-draft snapshot (cheap Arc clone) + O(j) replay on rejection; Llama/Qwen fall back to rebuilding from the last 128 context tokens
- CLI: `--draft-model PATH` and `--speculative-steps N` (default 5)
- `PerSeqCache::try_clone_external()` added for cheap snapshots of Mixtral external caches
- 7 new unit tests (distribution math, 2-D logit handling, correction sampling, degenerate fallback); 78 total passing

## Usage

```bash
vllm-hb serve \
  --model /models/Qwen2.5-7B-Instruct \
  --draft-model /models/Qwen2.5-0.5B-Instruct \
  --speculative-steps 5
```

## Test plan

- [x] `cargo check --no-default-features` clean
- [x] `cargo clippy --no-default-features -- -D warnings` clean
- [x] `cargo test --no-default-features` — 78/78 pass
- [ ] CI green on GitHub Actions
- [ ] End-to-end acceptance rate measurement on 4090 (future benchmark PR)

Closes #10