### PR TITLE
feat: Gemma 4 scaffolding + compressed-tensors loader (closes #39, #40)

### DIFF
--- a/src/engine/arch/gemma4.rs
+++ b/src/engine/arch/gemma4.rs
@@ -1,0 +1,269 @@
+//! Google Gemma 4 architecture backend.
+//!
+//! # Status: SCAFFOLDING ONLY (Phase 0)
+//!
+//! Parses [`Gemma4Config`] from `config.json` and logs the detected
+//! architecture, then returns an error from [`Gemma4Backend::load`].
+//! Forward pass not yet implemented.  See:
+//!
+//! - Phase 1 (#40) — compressed-tensors pack-quantized weight loader
+//! - Phase 2 (#41) — W4A16 int4 GEMM kernel for sm_70
+//! - Phase 3 (#42) — decoder block (mixed attention, proportional RoPE)
+//! - Phase 4 (#43) — MoE router + 128-expert forward pass
+//! - Phase 5 (#44) — full model + KV cache + backend integration
+//! - Phase 6 (#45) — parity testing + V100 bench + kernel tuning
+//!
+//! # Detection
+//!
+//! Dispatched on `model_type == "gemma4"` in `config.json`.  Gemma 4
+//! nests the text-model fields inside a `text_config` block; see
+//! [`crate::engine::config::HfMeta`] for how that flattens for the
+//! top-level engine dispatch.
+//!
+//! # The 26B-A4B checkpoint shape (what we're targeting)
+//!
+//! - 30 decoder layers, hidden 2816
+//! - Two attention variants *per model*:
+//!   - sliding layers (25 of 30): `head_dim=256`, `num_kv_heads=8`,
+//!     default RoPE θ=10k, window=1024
+//!   - full layers (5 of 30, every 6th): `global_head_dim=512`,
+//!     `num_global_key_value_heads=2`, proportional RoPE θ=1M,
+//!     `partial_rotary_factor=0.25`
+//! - `attention_k_eq_v=true` — K/V share weights on full layers
+//! - MoE per layer: 128 experts, top-8 routing, `moe_intermediate_size=704`
+//! - Dense MLP per layer: `intermediate_size=2112`, `gelu_pytorch_tanh`
+//! - `final_logit_softcapping=30.0`
+//! - Tied word embeddings
+
+#![allow(dead_code, unused_variables, unused_imports)]
+
+use anyhow::{Context, Result, bail};
+use candle_core::{DType, Device, Tensor};
+use serde::Deserialize;
+
+// ── Gemma 4 config (text portion only) ────────────────────────────────────────
+
+/// Parsed `text_config` subtree of a Gemma 4 `config.json`.
+///
+/// Audio and vision towers are skipped — this port is text-only.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Gemma4TextConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub max_position_embeddings: usize,
+
+    /// Full-attention layers use this head dim (different from sliding).
+    #[serde(default)]
+    pub global_head_dim: usize,
+    /// Full-attention layers use this KV head count.
+    #[serde(default)]
+    pub num_global_key_value_heads: usize,
+
+    #[serde(default)]
+    pub enable_moe_block: bool,
+    #[serde(default)]
+    pub num_experts: usize,
+    #[serde(default)]
+    pub top_k_experts: usize,
+    #[serde(default)]
+    pub moe_intermediate_size: usize,
+
+    pub sliding_window: usize,
+    #[serde(default = "default_true")]
+    pub use_sliding_window: bool,
+
+    /// Per-layer type: "sliding_attention" or "full_attention".
+    #[serde(default)]
+    pub layer_types: Vec<String>,
+
+    #[serde(default)]
+    pub final_logit_softcapping: Option<f64>,
+
+    #[serde(default)]
+    pub attention_k_eq_v: bool,
+
+    pub rms_norm_eps: f64,
+
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+
+    #[serde(default)]
+    pub hidden_activation: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Top-level Gemma 4 config wrapper.  Only `text_config` is used — audio
+/// and vision towers are skipped in this port.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Gemma4Config {
+    pub model_type: String,
+    pub text_config: Gemma4TextConfig,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+}
+
+impl Gemma4Config {
+    /// Parse a raw `config.json` string into a `Gemma4Config`.
+    ///
+    /// Returns an error with useful context if the schema doesn't match.
+    pub fn from_config_json(s: &str) -> Result<Self> {
+        let cfg: Self = serde_json::from_str(s)
+            .context("Parsing config.json as Gemma4Config (text_config required)")?;
+        if cfg.model_type != "gemma4" {
+            bail!(
+                "Gemma4Config expected model_type=\"gemma4\", got {:?}",
+                cfg.model_type
+            );
+        }
+        Ok(cfg)
+    }
+}
+
+// ── Backend stub ──────────────────────────────────────────────────────────────
+
+pub struct Gemma4Backend {
+    pub config: Gemma4Config,
+    pub device: Device,
+    #[allow(dead_code)]
+    dtype: DType,
+}
+
+impl Gemma4Backend {
+    pub fn load(
+        config_str: &str,
+        _shards: &[std::path::PathBuf],
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Self> {
+        let cfg = Gemma4Config::from_config_json(config_str)?;
+        let t = &cfg.text_config;
+
+        tracing::info!(
+            vocab = t.vocab_size,
+            hidden = t.hidden_size,
+            layers = t.num_hidden_layers,
+            heads = t.num_attention_heads,
+            kv_heads = t.num_key_value_heads,
+            head_dim = t.head_dim,
+            global_head_dim = t.global_head_dim,
+            moe_enabled = t.enable_moe_block,
+            experts = t.num_experts,
+            top_k_experts = t.top_k_experts,
+            sliding_window = t.sliding_window,
+            "Gemma 4 architecture detected (scaffolding only — forward pass not implemented)"
+        );
+
+        bail!(
+            "Gemma 4 forward pass is not yet implemented. \
+             Config parsed successfully; see issues #39-45 for the \
+             6-phase port roadmap. This backend can load the config but \
+             cannot run inference yet."
+        )
+    }
+
+    pub fn forward(&self, _token_ids: &[u32], _seq_pos: usize) -> Result<Tensor> {
+        unreachable!("Gemma4Backend::load always fails at this phase")
+    }
+
+    pub fn reset_cache(&self) -> Result<()> {
+        unreachable!("Gemma4Backend::load always fails at this phase")
+    }
+
+    pub fn create_kv_cache(&self) -> Vec<Option<(Tensor, Tensor)>> {
+        unreachable!("Gemma4Backend::load always fails at this phase")
+    }
+
+    pub fn forward_with_cache(
+        &self,
+        _token_ids: &[u32],
+        _seq_pos: usize,
+        _cache: &mut [Option<(Tensor, Tensor)>],
+    ) -> Result<Tensor> {
+        unreachable!("Gemma4Backend::load always fails at this phase")
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal shape matching google/gemma-4-26B-A4B-it config.json.
+    /// Not the full file — just enough to exercise the parser.
+    const GEMMA4_CONFIG_SNIPPET: &str = r#"{
+        "model_type": "gemma4",
+        "tie_word_embeddings": true,
+        "text_config": {
+            "vocab_size": 262144,
+            "hidden_size": 2816,
+            "intermediate_size": 2112,
+            "num_hidden_layers": 30,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "head_dim": 256,
+            "max_position_embeddings": 262144,
+            "global_head_dim": 512,
+            "num_global_key_value_heads": 2,
+            "enable_moe_block": true,
+            "num_experts": 128,
+            "top_k_experts": 8,
+            "moe_intermediate_size": 704,
+            "sliding_window": 1024,
+            "layer_types": [
+                "sliding_attention", "sliding_attention", "sliding_attention",
+                "sliding_attention", "sliding_attention", "full_attention"
+            ],
+            "final_logit_softcapping": 30.0,
+            "attention_k_eq_v": true,
+            "rms_norm_eps": 1e-06,
+            "hidden_activation": "gelu_pytorch_tanh"
+        }
+    }"#;
+
+    #[test]
+    fn parses_gemma4_config() {
+        let cfg = Gemma4Config::from_config_json(GEMMA4_CONFIG_SNIPPET).unwrap();
+        assert_eq!(cfg.model_type, "gemma4");
+        assert!(cfg.tie_word_embeddings);
+        let t = cfg.text_config;
+        assert_eq!(t.num_hidden_layers, 30);
+        assert_eq!(t.hidden_size, 2816);
+        assert_eq!(t.num_experts, 128);
+        assert_eq!(t.top_k_experts, 8);
+        assert_eq!(t.sliding_window, 1024);
+        assert_eq!(t.final_logit_softcapping, Some(30.0));
+        assert!(t.attention_k_eq_v);
+        assert_eq!(t.layer_types.len(), 6);
+        assert_eq!(t.global_head_dim, 512);
+    }
+
+    #[test]
+    fn rejects_wrong_model_type() {
+        let json = r#"{
+            "model_type": "llama",
+            "text_config": {
+                "vocab_size": 32000,
+                "hidden_size": 4096,
+                "intermediate_size": 11008,
+                "num_hidden_layers": 32,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 32,
+                "head_dim": 128,
+                "max_position_embeddings": 4096,
+                "sliding_window": 0,
+                "rms_norm_eps": 1e-5
+            }
+        }"#;
+        let err = Gemma4Config::from_config_json(json).unwrap_err();
+        assert!(err.to_string().contains("expected model_type=\"gemma4\""));
+    }
+}

--- a/src/engine/arch/mod.rs
+++ b/src/engine/arch/mod.rs
@@ -4,6 +4,7 @@
 //! devirtualize and inline the forward call completely.  When a new
 //! architecture is supported, add a variant here and a module below.
 
+pub mod gemma4;
 pub mod gguf_llama;
 pub mod llama;
 pub mod llama_tp;
@@ -15,6 +16,7 @@ pub mod qwen3;
 
 use anyhow::Result;
 use candle_core::Tensor;
+pub use gemma4::Gemma4Backend;
 pub use gguf_llama::GgufLlamaBackend;
 pub use llama::LlamaBackend;
 pub use llama_tp::TpLlamaBackend;
@@ -35,6 +37,8 @@ pub(crate) enum Backend {
     Qwen2(Qwen2Backend),
     Qwen3(Qwen3Backend),
     Phi3(Phi3Backend),
+    /// Google Gemma 4 MoE (scaffolding only — see issues #39-45).
+    Gemma4(Gemma4Backend),
     /// GGUF-quantized Llama (Q4_K_M, Q8_0, etc.)
     GgufLlama(GgufLlamaBackend),
 }
@@ -49,6 +53,7 @@ impl Backend {
             Self::Qwen2(m) => m.forward(token_ids, seq_pos),
             Self::Qwen3(m) => m.forward(token_ids, seq_pos),
             Self::Phi3(m) => m.forward(token_ids, seq_pos),
+            Self::Gemma4(m) => m.forward(token_ids, seq_pos),
             Self::GgufLlama(_) => anyhow::bail!("use forward_with_cache for GGUF models"),
         }
     }
@@ -62,6 +67,7 @@ impl Backend {
             Self::Qwen2(m) => m.reset_cache(),
             Self::Qwen3(m) => m.reset_cache(),
             Self::Phi3(m) => m.reset_cache(),
+            Self::Gemma4(m) => m.reset_cache(),
             Self::GgufLlama(_) => Ok(()), // KV is per-sequence; no global reset needed
         }
     }
@@ -76,6 +82,7 @@ impl Backend {
             Self::Qwen2(m) => Ok(PerSeqCache::Mixtral(m.create_kv_cache())),
             Self::Qwen3(m) => Ok(PerSeqCache::Mixtral(m.create_kv_cache())),
             Self::Phi3(m) => Ok(PerSeqCache::Mixtral(m.create_kv_cache())),
+            Self::Gemma4(m) => Ok(PerSeqCache::Mixtral(m.create_kv_cache())),
             Self::GgufLlama(m) => Ok(PerSeqCache::GgufLlama(m.create_seq_model())),
         }
     }
@@ -99,6 +106,9 @@ impl Backend {
                 m.forward_with_cache(token_ids, seq_pos, c)
             }
             (Self::Phi3(m), PerSeqCache::Mixtral(c)) => m.forward_with_cache(token_ids, seq_pos, c),
+            (Self::Gemma4(m), PerSeqCache::Mixtral(c)) => {
+                m.forward_with_cache(token_ids, seq_pos, c)
+            }
             (Self::GgufLlama(backend), PerSeqCache::GgufLlama(model)) => {
                 GgufLlamaBackend::forward(model, token_ids, seq_pos, &backend.device)
             }

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -30,7 +30,16 @@ pub struct ModelConfig {
 /// Minimal subset of HuggingFace `config.json` used for architecture
 /// detection and metadata logging.  We don't parse the full config here
 /// — each arch module does its own full parse.
-#[derive(Deserialize)]
+///
+/// # Nested `text_config` support
+///
+/// Most HF model configs expose `hidden_size`, `num_hidden_layers`, etc. at
+/// the top level.  Multimodal models (Gemma 4, PaliGemma, …) nest them
+/// inside a `text_config` block instead.  We parse via an intermediate
+/// [`HfMetaRaw`] with optional fields, then [`From`] fills the flat
+/// [`HfMeta`] from whichever location populated.  Existing call sites
+/// keep accessing `meta.hidden_size` unchanged.
+#[derive(Debug, Clone)]
 pub struct HfMeta {
     pub model_type: String,
     pub vocab_size: usize,
@@ -38,4 +47,123 @@ pub struct HfMeta {
     pub intermediate_size: usize,
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
+}
+
+#[derive(Deserialize)]
+struct HfMetaRaw {
+    model_type: String,
+    #[serde(default)]
+    vocab_size: Option<usize>,
+    #[serde(default)]
+    hidden_size: Option<usize>,
+    #[serde(default)]
+    intermediate_size: Option<usize>,
+    #[serde(default)]
+    num_hidden_layers: Option<usize>,
+    #[serde(default)]
+    num_attention_heads: Option<usize>,
+    #[serde(default)]
+    text_config: Option<HfMetaTextConfig>,
+}
+
+#[derive(Deserialize)]
+struct HfMetaTextConfig {
+    #[serde(default)]
+    vocab_size: Option<usize>,
+    #[serde(default)]
+    hidden_size: Option<usize>,
+    #[serde(default)]
+    intermediate_size: Option<usize>,
+    #[serde(default)]
+    num_hidden_layers: Option<usize>,
+    #[serde(default)]
+    num_attention_heads: Option<usize>,
+}
+
+impl From<HfMetaRaw> for HfMeta {
+    fn from(raw: HfMetaRaw) -> Self {
+        let tc = raw.text_config.as_ref();
+        let pick = |top: Option<usize>, sub: fn(&HfMetaTextConfig) -> Option<usize>| -> usize {
+            top.or_else(|| tc.and_then(sub)).unwrap_or(0)
+        };
+        Self {
+            model_type: raw.model_type,
+            vocab_size: pick(raw.vocab_size, |c| c.vocab_size),
+            hidden_size: pick(raw.hidden_size, |c| c.hidden_size),
+            intermediate_size: pick(raw.intermediate_size, |c| c.intermediate_size),
+            num_hidden_layers: pick(raw.num_hidden_layers, |c| c.num_hidden_layers),
+            num_attention_heads: pick(raw.num_attention_heads, |c| c.num_attention_heads),
+        }
+    }
+}
+
+impl HfMeta {
+    /// Parse from HuggingFace `config.json` string.  Handles both flat
+    /// configs (Llama, Qwen, Mixtral) and nested-text-config configs
+    /// (Gemma 4, PaliGemma).
+    pub fn from_config_json(s: &str) -> Result<Self, serde_json::Error> {
+        let raw: HfMetaRaw = serde_json::from_str(s)?;
+        Ok(raw.into())
+    }
+}
+
+// Backwards compat: let existing call sites keep using `serde_json::from_str`.
+impl<'de> Deserialize<'de> for HfMeta {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        HfMetaRaw::deserialize(d).map(Self::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flat_config_llama_style() {
+        let json = r#"{
+            "model_type": "llama",
+            "vocab_size": 32000,
+            "hidden_size": 4096,
+            "intermediate_size": 11008,
+            "num_hidden_layers": 32,
+            "num_attention_heads": 32
+        }"#;
+        let m: HfMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(m.model_type, "llama");
+        assert_eq!(m.hidden_size, 4096);
+        assert_eq!(m.num_hidden_layers, 32);
+    }
+
+    #[test]
+    fn nested_text_config_gemma4_style() {
+        // Shape matches google/gemma-4-26B-A4B-it config.json.
+        let json = r#"{
+            "model_type": "gemma4",
+            "text_config": {
+                "vocab_size": 262144,
+                "hidden_size": 2816,
+                "intermediate_size": 2112,
+                "num_hidden_layers": 30,
+                "num_attention_heads": 16
+            }
+        }"#;
+        let m: HfMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(m.model_type, "gemma4");
+        assert_eq!(m.hidden_size, 2816);
+        assert_eq!(m.num_hidden_layers, 30);
+        assert_eq!(m.vocab_size, 262144);
+    }
+
+    #[test]
+    fn top_level_wins_over_text_config() {
+        // When both locations have a value, the top-level one wins
+        // (matches HF's own resolution order for multimodal configs).
+        let json = r#"{
+            "model_type": "hybrid",
+            "hidden_size": 9999,
+            "text_config": { "hidden_size": 1111 }
+        }"#;
+        let m: HfMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(m.hidden_size, 9999);
+    }
 }

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -8,8 +8,8 @@ use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 
 use super::arch::{
-    Backend, GgufLlamaBackend, LlamaBackend, MixtralBackend, Phi3Backend, Qwen2Backend,
-    Qwen3Backend, TpLlamaBackend,
+    Backend, Gemma4Backend, GgufLlamaBackend, LlamaBackend, MixtralBackend, Phi3Backend,
+    Qwen2Backend, Qwen3Backend, TpLlamaBackend,
 };
 use super::config::{HfMeta, ModelConfig};
 use super::dtype;
@@ -149,9 +149,12 @@ impl Engine {
                 Backend::Qwen3(Qwen3Backend::load(&config_str, &shards, dtype, &device)?)
             }
             ("phi3", _) => Backend::Phi3(Phi3Backend::load(&config_str, &shards, dtype, &device)?),
+            ("gemma4", _) => {
+                Backend::Gemma4(Gemma4Backend::load(&config_str, &shards, dtype, &device)?)
+            }
             (other, _) => bail!(
                 "Unsupported model_type: {other:?}. \
-                 Supported: llama, mistral (TP-aware), mixtral, qwen2, qwen3."
+                 Supported: llama, mistral (TP-aware), mixtral, qwen2, qwen3, phi3, gemma4."
             ),
         };
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod dtype;
 pub mod kv_cache;
 pub mod loader;
+pub mod quant;
 
 // Primary public API — callers import `engine::Engine` and `engine::ModelConfig`.
 pub use config::ModelConfig;

--- a/src/engine/quant/compressed_tensors.rs
+++ b/src/engine/quant/compressed_tensors.rs
@@ -1,0 +1,684 @@
+//! Compressed-tensors pack-quantized format support.
+//!
+//! Parses the `quantization_config` block of an HF `config.json` produced
+//! by Neural Magic / Red Hat's `compressed-tensors` library (used by many
+//! HF checkpoints including `cyankiwi/gemma-4-*-AWQ-4bit`).
+//!
+//! # Weight layout on disk
+//!
+//! For a Linear of shape `[out_features, in_features]` the safetensors
+//! shard stores:
+//!
+//! - `<prefix>.weight_packed` — `[out_features, in_features / 8]` as
+//!   `int32`.  Each int32 holds 8 consecutive signed int4 values along
+//!   the `in_features` axis.  Slot 0 occupies bits 0-3, slot 7 bits 28-31.
+//! - `<prefix>.weight_scale` — `[out_features, in_features / group_size]`
+//!   in the model's native float dtype (fp16 or bf16).  Each scale
+//!   applies to `group_size` consecutive int4 values in `in_features`.
+//!
+//! `symmetric: true` (the only format we support here) means there is
+//! no zero-point — dequantized value = int4 × scale[group].  Asymmetric
+//! variants would have an additional `weight_zero_point` tensor.
+//!
+//! # Int4 unpack math
+//!
+//! For input index `i` along in_features:
+//! ```text
+//! int32_col = i / 8                  // which int32 word
+//! slot      = i % 8                  // which nibble within the word
+//! packed    = weight_packed[row, int32_col] as u32
+//! nibble    = (packed >> (slot * 4)) & 0xF
+//! int4      = if (nibble & 0x8) != 0 { nibble as i8 - 16 } else { nibble as i8 }
+//! group_idx = i / group_size
+//! dequant   = (int4 as f32) * (weight_scale[row, group_idx] as f32)
+//! ```
+
+use anyhow::{Context, Result, bail};
+use candle_core::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// ── Config types ──────────────────────────────────────────────────────────────
+
+/// Top-level `quantization_config` block from HF `config.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompressedTensorsConfig {
+    #[serde(default = "default_format")]
+    pub format: String,
+
+    pub config_groups: HashMap<String, CompressedTensorsGroup>,
+
+    /// Modules that are NOT quantized (loaded as regular fp16/bf16 tensors).
+    /// Common entries: `lm_head`, `router.proj`, first-N-layers mlp, vision tower.
+    #[serde(default)]
+    pub ignore: Vec<String>,
+
+    #[serde(default)]
+    pub quant_method: Option<String>,
+
+    #[serde(default)]
+    pub quantization_status: Option<String>,
+
+    #[serde(default)]
+    pub kv_cache_scheme: Option<serde_json::Value>,
+}
+
+fn default_format() -> String {
+    "pack-quantized".to_string()
+}
+
+/// One entry in `config_groups` — specifies quant args for a set of
+/// modules matching `targets`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompressedTensorsGroup {
+    #[serde(default = "default_format")]
+    pub format: String,
+    pub targets: Vec<String>,
+    pub weights: CompressedTensorsQuantArgs,
+    #[serde(default)]
+    pub input_activations: Option<serde_json::Value>,
+    #[serde(default)]
+    pub output_activations: Option<serde_json::Value>,
+}
+
+/// Per-group weight quantization args.  The subset we care about for
+/// pack-quantized W4A16 symmetric: `num_bits=4, group_size=*, symmetric=true, type="int"`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompressedTensorsQuantArgs {
+    pub num_bits: u32,
+    pub group_size: usize,
+    pub symmetric: bool,
+    #[serde(default = "default_type")]
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(default)]
+    pub strategy: Option<String>,
+    #[serde(default)]
+    pub observer: Option<String>,
+    #[serde(default)]
+    pub dynamic: bool,
+    #[serde(default)]
+    pub actorder: Option<serde_json::Value>,
+    #[serde(default)]
+    pub block_structure: Option<serde_json::Value>,
+    #[serde(default)]
+    pub scale_dtype: Option<String>,
+    #[serde(default)]
+    pub zp_dtype: Option<String>,
+}
+
+fn default_type() -> String {
+    "int".to_string()
+}
+
+impl CompressedTensorsConfig {
+    /// Extract the `quantization_config` sub-object from a raw config.json.
+    /// Returns `Ok(None)` if the config has no quantization metadata.
+    pub fn from_config_json(s: &str) -> Result<Option<Self>> {
+        #[derive(Deserialize)]
+        struct Outer {
+            #[serde(default)]
+            quantization_config: Option<CompressedTensorsConfig>,
+        }
+        let outer: Outer = serde_json::from_str(s)
+            .context("Parsing config.json to extract quantization_config")?;
+        Ok(outer.quantization_config)
+    }
+
+    /// Return the (single, for now) default group's quant args.  Real
+    /// checkpoints we've seen have exactly one group named `group_0`.
+    pub fn default_group(&self) -> Result<&CompressedTensorsGroup> {
+        // Prefer "group_0" if present, otherwise the first group.
+        if let Some(g) = self.config_groups.get("group_0") {
+            return Ok(g);
+        }
+        self.config_groups
+            .values()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("CompressedTensorsConfig has no config_groups"))
+    }
+
+    /// Check whether a given Linear prefix (e.g.
+    /// `"model.language_model.layers.0.mlp.gate_proj"`) is listed in
+    /// the `ignore` list, meaning it was NOT quantized.
+    pub fn is_ignored(&self, prefix: &str) -> bool {
+        // Exact match or prefix match with trailing dot.
+        self.ignore
+            .iter()
+            .any(|p| p == prefix || prefix.starts_with(&format!("{p}.")))
+    }
+}
+
+impl CompressedTensorsQuantArgs {
+    /// Validate that we support this combination of quant args.
+    pub fn validate_supported(&self) -> Result<()> {
+        if self.num_bits != 4 {
+            bail!(
+                "compressed-tensors: only num_bits=4 is supported, got {}",
+                self.num_bits
+            );
+        }
+        if !self.symmetric {
+            bail!(
+                "compressed-tensors: only symmetric=true is supported \
+                 (W4A16 symmetric). Asymmetric weight quant needs a \
+                 weight_zero_point tensor and different dequant math."
+            );
+        }
+        if self.ty != "int" {
+            bail!(
+                "compressed-tensors: only type=\"int\" is supported, got {:?}",
+                self.ty
+            );
+        }
+        if self.group_size == 0 || !self.group_size.is_multiple_of(8) {
+            bail!(
+                "compressed-tensors: group_size must be a nonzero multiple \
+                 of 8 (8 int4 values per int32), got {}",
+                self.group_size
+            );
+        }
+        Ok(())
+    }
+}
+
+// ── Int4 unpack + dequant ─────────────────────────────────────────────────────
+
+/// Dequantize a pack-quantized weight tensor pair to full-precision fp16/bf16/f32.
+///
+/// # Arguments
+///
+/// - `packed`   : `[out_features, in_features / 8]` with dtype I32 or U32
+/// - `scales`   : `[out_features, in_features / group_size]` with dtype F16 or BF16 or F32
+/// - `group_size` : number of int4 values per scale (must be multiple of 8)
+///
+/// # Returns
+///
+/// `[out_features, in_features]` tensor with the same dtype as `scales`.
+///
+/// # Performance
+///
+/// This is a CPU-side dequant-on-load path.  For large weights it is slow
+/// (seconds per GB).  Phase 2 (#41) will replace this with a CUDA kernel
+/// that keeps weights packed in VRAM and dequants in-register during GEMM.
+pub fn dequantize_pack_quantized(
+    packed: &Tensor,
+    scales: &Tensor,
+    group_size: usize,
+) -> Result<Tensor> {
+    if group_size == 0 || !group_size.is_multiple_of(8) {
+        bail!(
+            "dequantize_pack_quantized: group_size must be a nonzero multiple of 8, got {group_size}"
+        );
+    }
+
+    let packed_shape = packed.dims();
+    let scales_shape = scales.dims();
+    if packed_shape.len() != 2 {
+        bail!(
+            "dequantize_pack_quantized: packed must be 2D, got shape {:?}",
+            packed_shape
+        );
+    }
+    if scales_shape.len() != 2 {
+        bail!(
+            "dequantize_pack_quantized: scales must be 2D, got shape {:?}",
+            scales_shape
+        );
+    }
+
+    let out_features = packed_shape[0];
+    let in_features_per_int32 = packed_shape[1];
+    let in_features = in_features_per_int32 * 8;
+
+    if scales_shape[0] != out_features {
+        bail!(
+            "dequantize_pack_quantized: scales rows ({}) must match packed rows ({})",
+            scales_shape[0],
+            out_features
+        );
+    }
+    let groups_per_row = scales_shape[1];
+    if in_features != groups_per_row * group_size {
+        bail!(
+            "dequantize_pack_quantized: in_features ({}) != groups_per_row ({}) * group_size ({})",
+            in_features,
+            groups_per_row,
+            group_size
+        );
+    }
+
+    // Move tensors to CPU and materialize to host arrays for the loop.
+    // (We're running a pure-Rust dequant — CUDA path lives in Phase 2.)
+    let packed_cpu = packed.to_device(&Device::Cpu)?;
+    let scales_cpu = scales.to_device(&Device::Cpu)?;
+
+    // Packed can be stored as I32 (HF's PyTorch default) or U32; read as u32 via bitcast.
+    let packed_u32: Vec<u32> = match packed_cpu.dtype() {
+        DType::I32 => {
+            let v: Vec<i32> = packed_cpu.flatten_all()?.to_vec1()?;
+            v.into_iter().map(|x| x as u32).collect()
+        }
+        DType::U32 => packed_cpu.flatten_all()?.to_vec1()?,
+        dt => bail!(
+            "dequantize_pack_quantized: packed dtype must be I32 or U32, got {:?}",
+            dt
+        ),
+    };
+
+    // Scales keep their dtype; we dequant in f32 internally then cast back.
+    let scales_f32: Vec<f32> = scales_cpu.to_dtype(DType::F32)?.flatten_all()?.to_vec1()?;
+    let out_dtype = scales.dtype();
+
+    // Unpack into a dense f32 buffer.
+    let mut out = vec![0f32; out_features * in_features];
+    for row in 0..out_features {
+        let packed_base = row * in_features_per_int32;
+        let scales_base = row * groups_per_row;
+        let out_base = row * in_features;
+        for col_int32 in 0..in_features_per_int32 {
+            let word = packed_u32[packed_base + col_int32];
+            for slot in 0..8 {
+                let i = col_int32 * 8 + slot;
+                let group_idx = i / group_size;
+                let scale = scales_f32[scales_base + group_idx];
+                let nibble = ((word >> (slot * 4)) & 0xF) as i8;
+                // Sign-extend int4 → i8: if top bit set, subtract 16.
+                let int4 = if nibble & 0x8 != 0 {
+                    nibble - 16
+                } else {
+                    nibble
+                };
+                out[out_base + i] = (int4 as f32) * scale;
+            }
+        }
+    }
+
+    // Materialize as a candle tensor with the original scale dtype.
+    let t = Tensor::from_vec(out, (out_features, in_features), &Device::Cpu)?;
+    Ok(t.to_dtype(out_dtype)?.to_device(packed.device())?)
+}
+
+// ── VarBuilder integration ────────────────────────────────────────────────────
+
+/// Load a pack-quantized Linear weight from a VarBuilder, dequantizing to
+/// full precision at load time.
+///
+/// Returns the dequantized weight tensor with shape
+/// `[out_features, in_features]` and the VarBuilder's active dtype.
+///
+/// # Usage pattern (Phase 1 dequant-on-load path)
+///
+/// ```ignore
+/// let w = load_packed_weight(&vb.pp("gate_proj"), out, inp, 32)?;
+/// let bias = vb.pp("gate_proj").get(out, "bias").ok();
+/// let linear = candle_nn::Linear::new(w, bias);
+/// ```
+///
+/// # Expected safetensors keys (under the `vb` prefix)
+///
+/// - `weight_packed` — int32, shape `[out_features, in_features / 8]`
+/// - `weight_scale`  — fp16/bf16, shape `[out_features, in_features / group_size]`
+///
+/// Phase 2 (#41) will replace this with a path that keeps `packed` and
+/// `scales` resident on GPU and calls a fused W4A16 GEMM kernel instead
+/// of pre-dequantizing.
+pub fn load_packed_weight(
+    vb: &VarBuilder,
+    out_features: usize,
+    in_features: usize,
+    group_size: usize,
+) -> Result<Tensor> {
+    if !in_features.is_multiple_of(8) {
+        bail!(
+            "load_packed_weight: in_features ({}) must be a multiple of 8 \
+             (8 int4 values per int32)",
+            in_features
+        );
+    }
+    if !in_features.is_multiple_of(group_size) {
+        bail!(
+            "load_packed_weight: in_features ({}) must be a multiple of \
+             group_size ({})",
+            in_features,
+            group_size
+        );
+    }
+
+    let packed_shape = (out_features, in_features / 8);
+    let scales_shape = (out_features, in_features / group_size);
+
+    // compressed-tensors stores weight_packed as torch.int32. candle's
+    // VarBuilder.get() respects the dtype stored in the safetensors file
+    // — so we call get_with_hints_dtype to request I32 exactly.
+    let packed = vb
+        .get_with_hints_dtype(
+            packed_shape,
+            "weight_packed",
+            candle_nn::Init::Const(0.0),
+            DType::I32,
+        )
+        .with_context(|| {
+            format!(
+                "Loading weight_packed shape {:?} from safetensors",
+                packed_shape
+            )
+        })?;
+
+    // Scales are stored in the model's native float dtype. Use the
+    // VarBuilder's default dtype (fp16 on V100, bf16 on Ampere+).
+    let scales = vb.get(scales_shape, "weight_scale").with_context(|| {
+        format!(
+            "Loading weight_scale shape {:?} from safetensors",
+            scales_shape
+        )
+    })?;
+
+    dequantize_pack_quantized(&packed, &scales, group_size)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    // ── Config parse ──────────────────────────────────────────────────────────
+
+    const CYANKIWI_GEMMA4_CONFIG_SNIPPET: &str = r#"{
+        "model_type": "gemma4",
+        "quantization_config": {
+            "format": "pack-quantized",
+            "config_groups": {
+                "group_0": {
+                    "format": "pack-quantized",
+                    "targets": ["Linear"],
+                    "weights": {
+                        "num_bits": 4,
+                        "group_size": 32,
+                        "symmetric": true,
+                        "type": "int",
+                        "strategy": "group",
+                        "observer": "mse",
+                        "dynamic": false,
+                        "actorder": null,
+                        "block_structure": null,
+                        "scale_dtype": null,
+                        "zp_dtype": null
+                    },
+                    "input_activations": null,
+                    "output_activations": null
+                }
+            },
+            "ignore": [
+                "model.language_model.layers.0.mlp.gate_proj",
+                "lm_head"
+            ],
+            "quant_method": "compressed-tensors",
+            "quantization_status": "compressed"
+        }
+    }"#;
+
+    #[test]
+    fn parses_cyankiwi_gemma4_awq_config() {
+        let cfg = CompressedTensorsConfig::from_config_json(CYANKIWI_GEMMA4_CONFIG_SNIPPET)
+            .unwrap()
+            .expect("quantization_config must be present");
+        assert_eq!(cfg.format, "pack-quantized");
+        assert_eq!(cfg.quant_method.as_deref(), Some("compressed-tensors"));
+        assert_eq!(cfg.ignore.len(), 2);
+        assert!(cfg.is_ignored("lm_head"));
+        assert!(cfg.is_ignored("model.language_model.layers.0.mlp.gate_proj"));
+        // Prefix-with-dot match
+        assert!(cfg.is_ignored("model.language_model.layers.0.mlp.gate_proj.weight"));
+        assert!(!cfg.is_ignored("model.language_model.layers.1.mlp.gate_proj"));
+
+        let g = cfg.default_group().unwrap();
+        assert_eq!(g.weights.num_bits, 4);
+        assert_eq!(g.weights.group_size, 32);
+        assert!(g.weights.symmetric);
+        g.weights.validate_supported().unwrap();
+    }
+
+    #[test]
+    fn rejects_unsupported_num_bits() {
+        let args = CompressedTensorsQuantArgs {
+            num_bits: 8,
+            group_size: 32,
+            symmetric: true,
+            ty: "int".into(),
+            strategy: None,
+            observer: None,
+            dynamic: false,
+            actorder: None,
+            block_structure: None,
+            scale_dtype: None,
+            zp_dtype: None,
+        };
+        let err = args.validate_supported().unwrap_err();
+        assert!(err.to_string().contains("num_bits=4"));
+    }
+
+    #[test]
+    fn rejects_asymmetric() {
+        let args = CompressedTensorsQuantArgs {
+            num_bits: 4,
+            group_size: 32,
+            symmetric: false,
+            ty: "int".into(),
+            strategy: None,
+            observer: None,
+            dynamic: false,
+            actorder: None,
+            block_structure: None,
+            scale_dtype: None,
+            zp_dtype: None,
+        };
+        assert!(
+            args.validate_supported()
+                .unwrap_err()
+                .to_string()
+                .contains("symmetric=true")
+        );
+    }
+
+    // ── Int4 unpack ───────────────────────────────────────────────────────────
+
+    /// Hand-computed test case.
+    ///
+    /// Weight row [1, 2, 3, 4, -1, -2, -3, -4] packed into one int32:
+    ///   slot 0: 1  → bits 0-3  = 0x1
+    ///   slot 1: 2  → bits 4-7  = 0x2
+    ///   slot 2: 3  → bits 8-11 = 0x3
+    ///   slot 3: 4  → bits 12-15= 0x4
+    ///   slot 4: -1 → bits 16-19= 0xF (two's complement int4)
+    ///   slot 5: -2 → bits 20-23= 0xE
+    ///   slot 6: -3 → bits 24-27= 0xD
+    ///   slot 7: -4 → bits 28-31= 0xC
+    /// packed u32 = 0xCDEF_4321
+    ///
+    /// Scale = 0.5 (group_size=8 so one scale for the whole row).
+    /// Expected dequant: [0.5, 1.0, 1.5, 2.0, -0.5, -1.0, -1.5, -2.0]
+    #[test]
+    fn dequant_hand_packed_row_is_bit_exact() {
+        let dev = Device::Cpu;
+        let packed_u32: u32 = 0xCDEF_4321;
+        let packed = Tensor::from_vec(vec![packed_u32], (1, 1), &dev).unwrap();
+        let scales = Tensor::from_vec(vec![0.5_f32], (1, 1), &dev).unwrap();
+
+        let out = dequantize_pack_quantized(&packed, &scales, 8).unwrap();
+        assert_eq!(out.dims(), &[1, 8]);
+        let v: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
+        let expected = [0.5, 1.0, 1.5, 2.0, -0.5, -1.0, -1.5, -2.0];
+        for (i, (&got, &exp)) in v.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-6,
+                "slot {i}: got {got}, expected {exp}"
+            );
+        }
+    }
+
+    /// Boundary values: int4 range is [-8, 7].  Verify sign extension
+    /// at both ends.
+    #[test]
+    fn dequant_int4_boundary_values() {
+        let dev = Device::Cpu;
+        // Row of: 7, -8, 0, 1, 2, 3, 4, 5 all × scale=1.0
+        //   7 = 0x7, -8 = 0x8, 0 = 0x0, 1 = 0x1, ..., 5 = 0x5
+        let packed_u32: u32 = (0x7 << 0)
+            | (0x8 << 4)
+            | (0x0 << 8)
+            | (0x1 << 12)
+            | (0x2 << 16)
+            | (0x3 << 20)
+            | (0x4 << 24)
+            | (0x5 << 28);
+        let packed = Tensor::from_vec(vec![packed_u32], (1, 1), &dev).unwrap();
+        let scales = Tensor::from_vec(vec![1.0_f32], (1, 1), &dev).unwrap();
+
+        let out = dequantize_pack_quantized(&packed, &scales, 8).unwrap();
+        let v: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
+        assert_eq!(v, vec![7.0, -8.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    /// Multi-row, multi-group: verify that each row uses its own scales
+    /// and each group of `group_size` values maps to the right scale.
+    #[test]
+    fn dequant_multi_row_multi_group() {
+        let dev = Device::Cpu;
+        // 2 rows, 16 cols, group_size=8 → packed [2, 2] u32, scales [2, 2].
+        // Row 0: group 0 = all 1s (× scale 2.0), group 1 = all 2s (× scale 3.0)
+        // Row 1: group 0 = all 3s (× scale 0.1), group 1 = all -1s (× scale 10.0)
+        let row0_g0: u32 = 0x11111111; // eight 1s packed
+        let row0_g1: u32 = 0x22222222; // eight 2s packed
+        let row1_g0: u32 = 0x33333333; // eight 3s packed
+        let row1_g1: u32 = 0xFFFFFFFF; // eight -1s packed (two's complement)
+
+        let packed =
+            Tensor::from_vec(vec![row0_g0, row0_g1, row1_g0, row1_g1], (2, 2), &dev).unwrap();
+        let scales = Tensor::from_vec(vec![2.0_f32, 3.0, 0.1, 10.0], (2, 2), &dev).unwrap();
+
+        let out = dequantize_pack_quantized(&packed, &scales, 8).unwrap();
+        let v: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
+
+        let mut expected = vec![0f32; 32];
+        for i in 0..8 {
+            expected[i] = 1.0 * 2.0;
+        } // row 0, group 0
+        for i in 8..16 {
+            expected[i] = 2.0 * 3.0;
+        } // row 0, group 1
+        for i in 16..24 {
+            expected[i] = 3.0 * 0.1;
+        } // row 1, group 0
+        for i in 24..32 {
+            expected[i] = -1.0 * 10.0;
+        } // row 1, group 1
+
+        for i in 0..32 {
+            assert!(
+                (v[i] - expected[i]).abs() < 1e-5,
+                "slot {i}: got {}, expected {}",
+                v[i],
+                expected[i]
+            );
+        }
+    }
+
+    /// Using i32 storage (safetensors default) should work the same as u32.
+    #[test]
+    fn dequant_accepts_i32_packed() {
+        let dev = Device::Cpu;
+        // Same test as the first one but stored as i32.  Note that
+        // 0xCDEF4321 as u32 = -839915743 as i32 (since top bit set).
+        let packed_i32: i32 = 0xCDEF_4321_u32 as i32;
+        let packed = Tensor::from_vec(vec![packed_i32], (1, 1), &dev).unwrap();
+        let scales = Tensor::from_vec(vec![0.5_f32], (1, 1), &dev).unwrap();
+
+        let out = dequantize_pack_quantized(&packed, &scales, 8).unwrap();
+        let v: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
+        let expected = [0.5, 1.0, 1.5, 2.0, -0.5, -1.0, -1.5, -2.0];
+        for (got, exp) in v.iter().zip(expected.iter()) {
+            assert!((got - exp).abs() < 1e-6);
+        }
+    }
+
+    /// Invalid group_size is rejected cleanly.
+    #[test]
+    fn dequant_rejects_bad_group_size() {
+        let dev = Device::Cpu;
+        let packed = Tensor::from_vec(vec![0u32], (1, 1), &dev).unwrap();
+        let scales = Tensor::from_vec(vec![1.0f32], (1, 1), &dev).unwrap();
+        assert!(dequantize_pack_quantized(&packed, &scales, 0).is_err());
+        assert!(dequantize_pack_quantized(&packed, &scales, 7).is_err()); // not multiple of 8
+    }
+
+    // ── VarBuilder integration ────────────────────────────────────────────────
+
+    /// End-to-end: build an in-memory VarBuilder with synthetic packed +
+    /// scale tensors, load via `load_packed_weight`, assert dequantized
+    /// output matches hand-computed expected values.
+    #[test]
+    fn load_packed_weight_roundtrip() {
+        use candle_core::DType;
+        use candle_nn::VarMap;
+
+        let dev = Device::Cpu;
+        let vm = VarMap::new();
+        // Use f32 scales for the test (simpler numerics; real checkpoints use f16/bf16).
+        let vb = VarBuilder::from_varmap(&vm, DType::F32, &dev);
+
+        // Build the same hand-packed row as dequant_hand_packed_row_is_bit_exact,
+        // but inside a VarBuilder's VarMap so `load_packed_weight` can fetch them.
+        // Row of [1, 2, 3, 4, -1, -2, -3, -4] × scale 0.5.
+        let packed_u32: u32 = 0xCDEF_4321;
+        let packed_i32: i32 = packed_u32 as i32;
+        let packed = Tensor::from_vec(vec![packed_i32], (1, 1), &dev).unwrap();
+        let scales = Tensor::from_vec(vec![0.5_f32], (1, 1), &dev).unwrap();
+
+        {
+            // VarMap's set_one inserts a variable at the given name.
+            let mut data = vm.data().lock().unwrap();
+            data.insert(
+                "gate_proj.weight_packed".to_string(),
+                candle_core::Var::from_tensor(&packed).unwrap(),
+            );
+            data.insert(
+                "gate_proj.weight_scale".to_string(),
+                candle_core::Var::from_tensor(&scales).unwrap(),
+            );
+        }
+
+        let w = load_packed_weight(
+            &vb.pp("gate_proj"),
+            /*out*/ 1,
+            /*in*/ 8,
+            /*group*/ 8,
+        )
+        .unwrap();
+        assert_eq!(w.dims(), &[1, 8]);
+        let v: Vec<f32> = w.flatten_all().unwrap().to_vec1().unwrap();
+        let expected = [0.5, 1.0, 1.5, 2.0, -0.5, -1.0, -1.5, -2.0];
+        for (got, exp) in v.iter().zip(expected.iter()) {
+            assert!((got - exp).abs() < 1e-6, "got {}, expected {}", got, exp);
+        }
+    }
+
+    /// Shape mismatch (in_features not divisible by 8) is rejected early
+    /// with a clear message instead of panicking inside dequantize.
+    #[test]
+    fn load_packed_weight_rejects_bad_shapes() {
+        use candle_nn::VarMap;
+        let dev = Device::Cpu;
+        let vm = VarMap::new();
+        let vb = VarBuilder::from_varmap(&vm, DType::F32, &dev);
+        // in_features=7 is not a multiple of 8.
+        let err = load_packed_weight(&vb.pp("x"), 1, 7, 7).unwrap_err();
+        assert!(err.to_string().contains("multiple of 8"));
+        // in_features=16 but group_size=10 (not dividing)
+        let err = load_packed_weight(&vb.pp("x"), 1, 16, 10).unwrap_err();
+        assert!(err.to_string().contains("group_size"));
+    }
+}

--- a/src/engine/quant/mod.rs
+++ b/src/engine/quant/mod.rs
@@ -1,0 +1,23 @@
+//! Quantization support for weight-only quantized checkpoints.
+//!
+//! # Supported formats
+//!
+//! - **compressed-tensors pack-quantized** ([`compressed_tensors`]) — the
+//!   format used by Red Hat / Neural Magic quantizers and by many HF
+//!   checkpoints including `cyankiwi/gemma-4-*-AWQ-4bit`.  W4A16 symmetric
+//!   with per-group scales, int32-packed weights (8 int4 values per int32).
+//!
+//! # Phase status
+//!
+//! - ✅ Phase 1 (#40) — dequant-on-load fallback: packed weights →
+//!   fp16/bf16 tensors at load time, reuse existing matmul path.  Correct
+//!   but uses 4× more VRAM than keeping packed (defeats the point on
+//!   memory-tight hardware).
+//! - 🔜 Phase 2 (#41) — W4A16 fused GEMM kernel for sm_70.  Keeps weights
+//!   packed in VRAM, dequants per-tile in-register during matmul.
+
+pub mod compressed_tensors;
+
+pub use compressed_tensors::{
+    CompressedTensorsConfig, CompressedTensorsQuantArgs, dequantize_pack_quantized,
+};


### PR DESCRIPTION
## Summary

Phases 0 and 1 of the [Gemma 4 26B-A4B AWQ port roadmap](https://github.com/avarga1/vllm-hb/issues?q=is%3Aissue+label%3Agemma4+OR+%22Gemma+4%22) — adds model recognition, config parsing, backend stub, and the compressed-tensors pack-quantized weight loader. The dequant-on-load fallback ships now so Phases 3-5 (decoder, MoE, integration) can proceed against correct weights while Phase 2 (#41) works on the real W4A16 CUDA kernel in parallel.

### Phase 0 — scaffolding (#39)

- HfMeta learns to resolve `hidden_size` / `num_hidden_layers` / etc. from either the top level (Llama/Qwen) or a nested `text_config` block (Gemma 4 / PaliGemma multimodal wrappers). Backwards-compatible via custom Deserialize.
- New `src/engine/arch/gemma4.rs` captures the full 26B-A4B shape: mixed sliding/full attention with different head dims per layer type, 128-expert top-8 MoE, hybrid dense MLP + MoE per layer, `attention_k_eq_v`, logit softcap, sliding window.
- Backend enum + loader dispatch wired. Loading fails cleanly: parses config, logs architecture, bails with a pointer to the Phase 2-6 issues.

### Phase 1 — compressed-tensors loader (#40)

- Full `quantization_config` parser with `ignore` list support (for unquantized modules: `lm_head`, router, first-N layers' dense MLPs, vision tower).
- Pure-Rust int4 unpack with correct two's-complement sign extension (`[-8, 7]` range), group-scale multiply, i32/u32 dtype support.
- `load_packed_weight(vb, out, in, group_size)` VarBuilder helper returns a dequantized weight tensor ready for `Linear::new`.
- 10 unit tests covering: config parse against the real cyankiwi checkpoint snippet, validation rejection paths, bit-exact dequant with a hand-packed int32, int4 boundary values, multi-row/multi-group correctness, i32-vs-u32 equivalence, VarBuilder end-to-end round-trip, shape-mismatch early rejection.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --no-default-features -- -D warnings` — clean on Rust 1.95
- [x] `cargo test --no-default-features --lib` — 163/163 tests pass (15 new)
- [x] Loading a Gemma 4 model path fails cleanly with "not yet implemented" instead of "unknown model_type"

## What's next

- Phase 2 (#41) — W4A16 int4 symmetric GEMM CUDA kernel for sm_70 (V100). Replaces the Phase 1 dequant-on-load fallback with a fused kernel that keeps weights packed in VRAM. This is the hard one.
- Phase 3 (#42) — Gemma 4 decoder block.
- Phases 4-6 — MoE router, full model integration, parity testing.

Closes #39. Closes #40.